### PR TITLE
Strip spaces

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -40,7 +40,7 @@ mark_empty_lines () {
 
 strip_leading_symbols () {
 	# strip the + and -
-	$SED -E "s/^$color_code_regex[\+\-]/\1 /g"
+	$SED -E "s/^$color_code_regex[\ \+\-]/\1/g"
 }
 
 print_horizontal_rule () {


### PR DESCRIPTION
The point of stripping the symbols is to be able to easily copy and paste code. That is not currently ideal because there is a single space at the beginning of each line left.

Also, for the love of me, don't give an unsuspecting stranger commit rights :D