### PR TITLE
Making diff-so-fancy work on OS X out of the box

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -9,24 +9,25 @@ hash gsed 2> /dev/null && SED=gsed || SED=sed
 if hash diff-highlight 2> /dev/null; then
 	diff_highlight=diff-highlight
 else
-	SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
+	SCRIPT_PATH=$( cd $(dirname $(readlink $0 || echo $0)) ; pwd -P )
 	diff_highlight="$SCRIPT_PATH/third_party/diff-highlight/diff-highlight"
 fi
 
-color_code_regex="(\x1B\[([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"
-reset_color="\x1B\[m"
-dim_magenta="\x1B\[38;05;146m"
-invert_color="\x1B\[7m"
+CSI=$'\x1b\['
+color_code_regex="(($CSI([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?)"
+reset_color=$'\x1b\[0?m'
+dim_magenta=$'\x1b\[38;05;146m'
+invert_color=$'\x1b\[7m'
 
 git_index_line_pattern="^($color_code_regex)index .*"
 
 format_diff_header () {
-	# simplify the unified patch diff header
-	$SED -E "s/^($color_code_regex)diff --git .*$//g" | \
-	$SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//}" | \
+    # simplify the unified patch diff header
+	$SED -E -e "s/^($color_code_regex)diff --git .*$//" | \
+	$SED -E -e "/($git_index_line_pattern)/{N;s/$git_index_line_pattern\n//;}" | \
 	$SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\
-\1\-\-\-\5/g" | \
-	$SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\5\\
+\1\-\-\-\6/g" | \
+	$SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\6\\
 \1$(print_horizontal_rule)/g"
 }
 
@@ -36,12 +37,12 @@ colorize_context_line () {
 }
 
 mark_empty_lines () {
-	$SED -E "s/^$color_code_regex[\+\-]$reset_color\s*$/$invert_color\1 $reset_color/g"
+	$SED -E "s/^($color_code_regex)[\+\-]$reset_color\s*$/$invert_color\1 $reset_color/g"
 }
 
 strip_leading_symbols () {
 	# strip the + and -
-	$SED -E "s/^$color_code_regex[\+\-]/\1 /g"
+	$SED -E "s/^($color_code_regex)[\ \+\-]/\1/g"
 }
 
 print_horizontal_rule () {
@@ -49,4 +50,4 @@ print_horizontal_rule () {
 }
 
 # run it.
-cat $input | $diff_highlight | format_diff_header |  colorize_context_line | mark_empty_lines | strip_leading_symbols
+cat $input | $diff_highlight | format_diff_header | colorize_context_line | mark_empty_lines | strip_leading_symbols


### PR DESCRIPTION
- Using bash string quoting '$' to match colors with bsd sed
- Fixing problems with symlinked diff-so-fancy