### PR TITLE
Making diff-so-fancy work on OS X out of the box

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -22,17 +22,19 @@ else
 	diff_highlight="$(get_script_dir)/third_party/diff-highlight/diff-highlight"
 fi
 
-color_code_regex="(\x1B\[([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"
-reset_color="\x1B\[m"
-dim_magenta="\x1B\[35m\x1B\[2m"
-invert_color="\x1B\[7m"
+CSI=$'\x1b\['
+color_code_regex="(${CSI}([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"
+reset_color="${CSI}0?m"
+reset_escape="${CSI}m"
+dim_magenta="${CSI}38;05;146m"
+invert_color="${CSI}7m"
 
 git_index_line_pattern="^($color_code_regex)index .*"
 
 format_diff_header () {
 	# simplify the unified patch diff header
 	$SED -E "s/^($color_code_regex)diff --git .*$//g" | \
-	$SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//}" | \
+	$SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//;}" | \
 	$SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\
 \1\-\-\-\5/g" | \
 	$SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\5\\
@@ -44,8 +46,10 @@ colorize_context_line () {
 	$SED -E "s/@@$reset_color $reset_color(.*$)/@@ $dim_magenta\1/g"
 }
 
+
+     
 mark_empty_lines () {
-	$SED -E "s/^$color_code_regex[\+\-]$reset_color\s*$/$invert_color\1 $reset_color/g"
+	$SED -E "s/^$color_code_regex[\+\-]$reset_color\s*$/$invert_color\1 $reset_escape/g"
 }
 
 strip_leading_symbols () {
@@ -58,4 +62,4 @@ print_horizontal_rule () {
 }
 
 # run it.
-cat $input | $diff_highlight | format_diff_header |  colorize_context_line | mark_empty_lines | strip_leading_symbols
+cat $input | $diff_highlight | format_diff_header | colorize_context_line | mark_empty_lines | strip_leading_symbols


### PR DESCRIPTION
- Using bash string quoting '$' to match colors with bsd sed
- Accepting either CSI0m or CSIm as reset sequences
  - Emitting only CSI0m