### PR TITLE
Strip empty spaces alternative

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -55,7 +55,11 @@ mark_empty_lines () {
 
 strip_leading_symbols () {
   # strip the + and -
-  $SED -E "s/^$color_code_regex[\+\-]/\1 /g"
+  $SED -E "s/^($color_code_regex)[\+\-]/\1 /g"
+}
+
+strip_first_column () {
+  $SED -E "s/^($color_code_regex)[[:space:]]/\1/g"
 }
 
 print_horizontal_rule () {
@@ -69,4 +73,5 @@ cat $input \
   | format_diff_header \
   | colorize_context_line \
   | mark_empty_lines \
-  | strip_leading_symbols
+  | strip_leading_symbols \
+  | strip_first_column

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,8 @@ git diff --color | diff-so-fancy
 
 **But**, you'll probably want to fancify all your diffs. Run this so `git diff` (and `git show`) will use it:
 ```shell
-git config --global pager.diff "diff-so-fancy | less --tabs=1,5 -RFX"
-git config --global pager.show "diff-so-fancy | less --tabs=1,5 -RFX"
+git config --global pager.diff "diff-so-fancy | less --tabs=4 -RFX"
+git config --global pager.show "diff-so-fancy | less --tabs=4 -RFX"
 ```
 
 However, if you'd prefer to do the fanciness on-demand with `git dsf`, drop an alias in your `~/.gitconfig`:

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -15,7 +15,7 @@ output=$( load_fixture "ls-function" | $diff_so_fancy )
 
 @test "original source is indented by a single space" {
   assert_output --partial "
- if begin[m"
+if begin[m"
 }
 
 @test "index line is removed entirely" {
@@ -31,9 +31,9 @@ output=$( load_fixture "ls-function" | $diff_so_fancy )
 
 @test "empty lines added/removed are marked" {
   assert_output --partial "[7m[1;32m [m
-[1;32m [m[1;32m    set -x CLICOLOR_FORCE 1[m"
+[1;32m[m[1;32m    set -x CLICOLOR_FORCE 1[m"
   assert_output --partial "[7m[1;31m [m
-   if not set -q LS_COLORS[m"
+  if not set -q LS_COLORS[m"
 }
 
 @test "diff-highlight is highlighting changes within lines" {


### PR DESCRIPTION
Alternative implementation for #51 which takes into account empty lines.

Before:
![before](https://cloud.githubusercontent.com/assets/717109/13033336/474f934a-d31c-11e5-8bbd-a3c210be6596.png)

After:
![after](https://cloud.githubusercontent.com/assets/717109/13033337/4ac08034-d31c-11e5-925d-425e3b85f122.png)
