### PR TITLE
Remove -RFX flags from less; git provides these

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,8 @@ git diff --color | diff-so-fancy
 
 **But**, you'll probably want to fancify all your diffs. Run this so `git diff` (and `git show`) will use it:
 ```shell
-git config --global pager.diff "diff-so-fancy | less --tabs=1,5 -RFX"
-git config --global pager.show "diff-so-fancy | less --tabs=1,5 -RFX"
+git config --global pager.diff "diff-so-fancy | less --tabs=1,5"
+git config --global pager.show "diff-so-fancy | less --tabs=1,5"
 ```
 
 However, if you'd prefer to do the fanciness on-demand with `git dsf`, drop an alias in your `~/.gitconfig`:


### PR DESCRIPTION
[Git will by default set the `LESS` environment variable to `FRX`][git-less], so we don't need to set it manually.

[git-less]: https://github.com/git/git/blob/v2.7.1/Documentation/config.txt#L646-L648