### PR TITLE
rename perl interpreter to /usr/bin/env perl

### DIFF
--- a/third_party/diff-highlight/diff-highlight
+++ b/third_party/diff-highlight/diff-highlight
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use 5.008;
 use warnings FATAL => 'all';


### PR DESCRIPTION
I and other Nix/NixOS users do not have perl at location /usr/bin/perl