### PR TITLE
add fixes for powershell

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -64,6 +64,10 @@ strip_first_column () {
 print_horizontal_rule () {
   let width="$(tput cols)"
 
+  if [[ $(uname -s) =~ (MINGW32*|MSYS*) ]]; then
+    width=$(( width - 1 ))
+  fi
+
   # echo -n '─' | hexdump -C
   local -r dash=$( printf "%b" "\xe2\x94\x80" )
   printf "%*s\n" "$width" | $SED "s/ /${dash}/g"

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -62,7 +62,11 @@ strip_first_column () {
 }
 
 print_horizontal_rule () {
-  printf "%$(tput cols)s\n"| $SED 's/ /─/g'
+  let width="$(tput cols)"
+
+  # echo -n '─' | hexdump -C
+  local -r dash=$( printf "%b" "\xe2\x94\x80" )
+  printf "%*s\n" "$width" | $SED "s/ /${dash}/g"
 }
 
 print_header_clean () {

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -22,7 +22,7 @@ if begin[m"
   refute_output --partial "index 33c3d8b..fd54db2 100644"
 }
 
-@test "+/- line stars are stripped" {
+@test "+/- line symbols are stripped" {
   refute_output --partial "
 [1;31m-"
   refute_output --partial "

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -43,3 +43,11 @@ if begin[m"
   output=$( load_fixture "noprefix" | $diff_so_fancy )
   refute_output --partial "diff --git setup-a-new-machine.sh"
 }
+
+@test "header format uses a native line-drawing character" {
+  header=$( printf "%s" "$output" | head -n3 )
+  run printf "%s" "$header"
+  assert_line --index 0 --partial "[1;33m─────"
+  assert_line --index 1 --partial "modified: fish/functions/ls.fish"
+  assert_line --index 2 --partial "[1;33m─────"
+}


### PR DESCRIPTION
 * 4e5800f; Related to #7
   * I ran into this issue on a Windows console emulator (ConEmu; cmder) using a bitmap font (ProggyCleanTTSZ). 
```
ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö

--- a/fish/functions/ls.fish
+++ b/fish/functions/ls.fish

ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö

@@ -7,6 +7,8 @@
```


 * cb0c0f1
   * For some reason PowerShell wraps a line at terminal width and needs a small tweak that keeps the header formatted properly.

-----
**Fixes tested on Windows (PowerShell, cygwin), OS X (iTerm, terminator, terminal)**

**Windows (cmder)** (via `npm link`)
![image](https://cloud.githubusercontent.com/assets/4911400/13384173/23e523a2-de61-11e5-9f14-c740bda57f17.png)

**OSX (terminal)**
![image](https://cloud.githubusercontent.com/assets/4911400/13384286/30a59b84-de62-11e5-827f-7c4c2c360477.png)
