### PR TITLE
test: add fixture for diff=noprefix

### DIFF
--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -37,6 +37,9 @@ if begin[m"
 }
 
 @test "diff --git line is removed entirely" {
-  output=$( load_fixture "noprefix" | $diff_so_fancy )
+  # test against ls-function
   refute_output --partial "diff --git a/fish/functions/ls.fish"
+  # test with git config diff.noprefix true
+  output=$( load_fixture "noprefix" | $diff_so_fancy )
+  refute_output --partial "diff --git setup-a-new-machine.sh"
 }

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -36,7 +36,7 @@ if begin[m"
   if not set -q LS_COLORS[m"
 }
 
-@test "diff-highlight is highlighting changes within lines" {
-  assert_output --partial 'eval [m[1;31;48;5;52m"env CLICOLOR_FORCE=1 command $ls $param [m[1;31m$argv"[m'
-  assert_output --partial 'eval [m[1;32;48;5;22m$ls $param "[m[1;32m$argv"[m'
+@test "diff --git line is removed entirely" {
+  output=$( load_fixture "noprefix" | $diff_so_fancy )
+  refute_output --partial "diff --git a/fish/functions/ls.fish"
 }

--- a/test/fixtures/noprefix.diff
+++ b/test/fixtures/noprefix.diff
@@ -1,0 +1,20 @@
+[1;33mdiff --git setup-a-new-machine.sh setup-a-new-machine.sh[m
+[1;33mindex 7b5996c..67eec2a 100755[m
+[1;33m--- setup-a-new-machine.sh[m
+[1;33m+++ setup-a-new-machine.sh[m
+[1;35m@@ -30,6 +30,7 @@[m [mcp -R ~/.gnupg ~/migration/home[m
+ cp /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist ~/migration  # wifi[m
+ [m
+ cp ~/Library/Preferences/net.limechat.LimeChat.plist ~/migration[m
+[1;32m+[m[1;32mcp ~/Library/Preferences/com.tinyspeck.slackmacgap.plist ~/migration[m
+ [m
+ cp -R ~/Library/Services ~/migration # automator stuff[m
+ [m
+[1;35m@@ -215,5 +216,7 @@[m [msh .osx[m
+ # symlink it up![m
+ ./symlink-setup.sh[m
+ [m
+[1;32m+[m[1;32m# add manual symlink for .ssh/config and probably .config/fish[m
+[1;32m+[m
+ ###[m
+ ##############################################################################################################[m


### PR DESCRIPTION
added tests to confirm the "git --diff" line is removed, even if `git config diff.noprefix true` is applied

thix test will catch the bug here: https://github.com/so-fancy/diff-so-fancy/pull/102#issuecomment-191600576

<hr>

also removed the ""diff-highlight is highlighting changes within lines" test from diff-so-fancy.bats as it was supposed to be removed: https://github.com/so-fancy/diff-so-fancy/commit/f15814cd307d8fd9e770fa5c3e0f12c4ba511e30