### PR TITLE
Rework how git hunks are displayed

### DIFF
--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -109,7 +109,7 @@ sub strip_empty_first_line {
 	my $foo = shift(); # Array passed in by reference
 
 	# If the first line is just whitespace remove it
-	if ($foo->[0] =~ /^\s*$/) {
+	if (defined($foo->[0]) && $foo->[0] =~ /^\s*$/) {
 		shift($foo);
 	}
 }

--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -23,7 +23,7 @@ for (my $i = 0; $i <= $#input; $i++) {
 	#########################
 	# Look for the filename #
 	#########################
-	if ($line =~ /^${ansi_sequence_regex}diff --(git|cc) (.*?)(\e|$)/) {
+	if ($line =~ /^${ansi_sequence_regex}diff --(git|cc) (.*?)(\s|\e|$)/) {
 		$last_file_seen = $5;
 		$last_file_seen =~ s|a/||; # Remove a/
 	########################################

--- a/test/header_clean.bats
+++ b/test/header_clean.bats
@@ -44,3 +44,9 @@ output=$( load_fixture "file-moves" | $diff_so_fancy )
 	assert_output --partial '@ square.yml:3 @'
 	assert_output --partial '@ package.json:4 @'
 }
+
+@test "Reworked hunks (noprefix)" {
+	output=$( load_fixture "noprefix" | $diff_so_fancy )
+	assert_output --partial '@ setup-a-new-machine.sh:33 @'
+	assert_output --partial '@ setup-a-new-machine.sh:218 @'
+}

--- a/test/header_clean.bats
+++ b/test/header_clean.bats
@@ -38,3 +38,9 @@ output=$( load_fixture "file-moves" | $diff_so_fancy )
 	output=$( load_fixture "file-perms" | $diff_so_fancy )
 	refute_output --partial 'diff --git'
 }
+
+@test "Reworked hunks" {
+	output=$( load_fixture "file-moves" | $diff_so_fancy )
+	assert_output --partial 'square.yml:3'
+	assert_output --partial 'package.json:4'
+}

--- a/test/header_clean.bats
+++ b/test/header_clean.bats
@@ -41,6 +41,6 @@ output=$( load_fixture "file-moves" | $diff_so_fancy )
 
 @test "Reworked hunks" {
 	output=$( load_fixture "file-moves" | $diff_so_fancy )
-	assert_output --partial 'square.yml:3'
-	assert_output --partial 'package.json:4'
+	assert_output --partial '@ square.yml:3 @'
+	assert_output --partial '@ package.json:4 @'
 }


### PR DESCRIPTION
This addresses things discussed in #100 

Also there is a minor bugfix in a92e9cf. If you ran diff-so-fancy with no changed files there would have been a warning emitted because there was not output to parse.