### PR TITLE
use .gitconfig for configuration

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -15,6 +15,18 @@ get_script_dir () {
   echo "$dir"
 }
 
+get_config() {
+  local -r key="diff-so-fancy.$1"
+  local -r default_value="$2"
+  value="$(git config --get "$key")"
+
+  if [[ -z "$value" && ! -z "$default_value" ]]; then
+    value="$default_value"
+  fi
+  printf "%s" "$value"
+}
+
+
 # find my sed
 hash gsed 2> /dev/null && SED=gsed || SED=sed
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -47,6 +47,7 @@ dim_magenta="${CSI}38;05;146m"
 invert_color="${CSI}7m"
 
 git_index_line_pattern="^($color_code_regex)index .*"
+diffsymbols="$(get_config 'diffsymbols' false)"
 
 format_diff_header () {
   # simplify the unified patch diff header
@@ -65,12 +66,20 @@ mark_empty_lines () {
 }
 
 strip_leading_symbols () {
-  # strip the + and -
-  $SED -E "s/^($color_code_regex)[\+\-]/\1 /g"
+  if [[ "$diffsymbols" = true ]]; then
+    cat
+  else
+    # strip the + and -
+    $SED -E "s/^($color_code_regex)[\+\-]/\1 /g"
+  fi
 }
 
 strip_first_column () {
-  $SED -E "s/^($color_code_regex)[[:space:]]/\1/g"
+  if [[ "$diffsymbols" = true ]]; then
+    cat
+  else
+    $SED -E "s/^($color_code_regex)[[:space:]]/\1/g"
+  fi
 }
 
 print_horizontal_rule () {

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -62,7 +62,11 @@ colorize_context_line () {
 }
 
 mark_empty_lines () {
-  $SED -E "s/^$color_code_regex[\+\-]$reset_color\s*$/$invert_color\1 $reset_escape/g"
+  if [[ "$diffsymbols" = true ]]; then
+    cat
+  else
+    $SED -E "s/^$color_code_regex[\+\-]$reset_color\s*$/$invert_color\1 $reset_escape/g"
+  fi
 }
 
 strip_leading_symbols () {

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -16,12 +16,9 @@ get_script_dir () {
 }
 
 get_config() {
-  local -r key="diff-so-fancy.$1"
-  local -r default_value="$2"
-  value="$(git config --get "$key")"
-
-  if [[ -z "$value" && ! -z "$default_value" ]]; then
-    value="$default_value"
+  value="$(git config --get "diff-so-fancy.$1")"
+  if [[ $value && ! -z $2 ]]; then
+    value="$2"
   fi
   printf "%s" "$value"
 }

--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -29,12 +29,12 @@ for (my $i = 0; $i <= $#input; $i++) {
 	########################################
 	# Find the first file: --- a/README.md #
 	########################################
-	} elsif ($line =~ /^$ansi_sequence_regex--- (\w\/)?(.+?)(\e|$)/) {
+	} elsif ($line =~ /^$ansi_sequence_regex--+ (\w\/)?(.+?)(\e|$)/) {
 		$file_1 = $5;
 
 		# Find the second file on the next line: +++ b/README.md
 		my $next = $input[++$i];
-		$next    =~ /^$ansi_sequence_regex\+\+\+ (\w\/)?(.+?)(\e|$)/;
+		$next    =~ /^$ansi_sequence_regex\+\++ (\w\/)?(.+?)(\e|$)/;
 		if ($1) {
 			print $1; # Print out whatever color we're using
 		}
@@ -59,7 +59,7 @@ for (my $i = 0; $i <= $#input; $i++) {
 	########################################
 	# Check for "@@ -3,41 +3,63 @@" syntax #
 	########################################
-	} elsif ($change_hunk_indicators && $line =~ /^${ansi_sequence_regex}(@@@* .+? @@@*)(.*)/) {
+	} elsif ($change_hunk_indicators && $line =~ /^${ansi_sequence_regex}(@@+ .+? @@@*)(.*)/) {
 
 		my $hunk_header  = $4;
 		my $remain       = $5;


### PR DESCRIPTION
this is just a proof of concept/work in progress on how we can add user-defined configurations. i chose this route over arguments so you can configure this on the `--local` level of `--global` (or `--system`) 

this is an example for #69 (`--plus-signs`). it would allow for easier customizations in the future

points of interest/questions:
 * git only accepts alphanumeric keys hence `diffsymbols` vs something more readable
 * configurations can grow to have a number of permutations, how exactly do we want to test this?
 * **help**: i've been running into issues with `header_clean`
   1. [on master] `diff --git a/diff-so-fancy b/diff-so-fancy` is always visible
   2. <strike>[on this branch] doesn't want to take input from `cat`</strike> fixed via 2549765
 * tbd: how we define the sections (see below)

**option 1**: shared namespace/section (tidier and more idiomatic)
```sh
[diff-so-fancy]
  diffsymbols = false
```

**option 2**: namespace by feature/section (potentially busy)
```sh
[diff-so-fancy "lines"]
  diffsymbols = true
```

![image](https://cloud.githubusercontent.com/assets/4911400/13546682/a8b63aa0-e283-11e5-981b-bdd34ee2a0c1.png)
