### PR TITLE
Change hunk line position: original --> result location

### DIFF
--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -67,7 +67,7 @@ for (my $i = 0; $i <= $#input; $i++) {
 			print $1; # Print out whatever color we're using
 		}
 
-		my ($start_line) = $file_str =~ m/(.+?),/;
+		my ($start_line) = $file_str =~ m/\+(\d+)/;
 		$start_line      = abs($start_line + 0);
 
 		$last_file_seen = basename($last_file_seen);

--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -59,22 +59,21 @@ for (my $i = 0; $i <= $#input; $i++) {
 	########################################
 	# Check for "@@ -3,41 +3,63 @@" syntax #
 	########################################
-	} elsif ($change_hunk_indicators && $line =~ /^${ansi_sequence_regex}@@@* (.+?) @@@*(.*)/) {
-		my $file_str     = $4;
+	} elsif ($change_hunk_indicators && $line =~ /^${ansi_sequence_regex}(@@@* .+? @@@*)(.*)/) {
+
+		my $hunk_header  = $4;
 		my $remain       = $5;
 
 		if ($1) {
 			print $1; # Print out whatever color we're using
 		}
 
-		my ($start_line) = $file_str =~ m/\+(\d+)/;
-		$start_line      = abs($start_line + 0);
-
+		my ($orig_offset, $orig_count, $new_offset, $new_count) = parse_hunk_header($hunk_header);
 		$last_file_seen = basename($last_file_seen);
 
 		# Plus three line for context
-		print "@ $last_file_seen:" . ($start_line + 3) . " \@${remain}\n";
-		#print $line;
+		print "@ $last_file_seen:" . ($new_offset + 3) . " \@${remain}\n";
+
 	###################################
 	# Remove any new file permissions #
 	###################################
@@ -103,6 +102,16 @@ for (my $i = 0; $i <= $#input; $i++) {
 	} else {
 		print $line;
 	}
+}
+
+# Courtesy of github.com/git/git/blob/ab5d01a/git-add--interactive.perl#L798-L805
+sub parse_hunk_header {
+    my ($line) = @_;
+    my ($o_ofs, $o_cnt, $n_ofs, $n_cnt) =
+        $line =~ /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+    $o_cnt = 1 unless defined $o_cnt;
+    $n_cnt = 1 unless defined $n_cnt;
+    return ($o_ofs, $o_cnt, $n_ofs, $n_cnt);
 }
 
 sub strip_empty_first_line {

--- a/test/header_clean.bats
+++ b/test/header_clean.bats
@@ -50,3 +50,8 @@ output=$( load_fixture "file-moves" | $diff_so_fancy )
 	assert_output --partial '@ setup-a-new-machine.sh:33 @'
 	assert_output --partial '@ setup-a-new-machine.sh:219 @'
 }
+
+@test "Reworked hunks (deleted files)" {
+	output=$( load_fixture "dotfiles" | $diff_so_fancy )
+	assert_output --partial '@ diff-so-fancy:3 @'
+}

--- a/test/header_clean.bats
+++ b/test/header_clean.bats
@@ -41,12 +41,12 @@ output=$( load_fixture "file-moves" | $diff_so_fancy )
 
 @test "Reworked hunks" {
 	output=$( load_fixture "file-moves" | $diff_so_fancy )
-	assert_output --partial '@ square.yml:3 @'
-	assert_output --partial '@ package.json:4 @'
+	assert_output --partial '@ square.yml:4 @'
+	assert_output --partial '@ package.json:3 @'
 }
 
 @test "Reworked hunks (noprefix)" {
 	output=$( load_fixture "noprefix" | $diff_so_fancy )
 	assert_output --partial '@ setup-a-new-machine.sh:33 @'
-	assert_output --partial '@ setup-a-new-machine.sh:218 @'
+	assert_output --partial '@ setup-a-new-machine.sh:219 @'
 }


### PR DESCRIPTION
If we take an example hunk header like `@@ -54,8 +51,7 @@`.. I think we want to surface the `51` as the line number as it's the likely currently representation of the change on disk. There are other ways in which diffs are viewed, but I think the most common usecases when linenumber is used by our users will be where the result line number is preferred to the original line number.

This change this also provides the ability to fix the error from #109. 
(However if we wanted to fix that without changing logic, we'd tweak this regex from `/(.+?),/` to `/-(\d+)/`)

PR adds a test for the bug. And it rebaselines the existing tests.

@scottchiefbaker whatcha think?

cc @lode 