### PR TITLE
Clean up some Perl that perlcritic.com didn't like

### DIFF
--- a/libs/header_clean/header_clean.pl
+++ b/libs/header_clean/header_clean.pl
@@ -112,4 +112,6 @@ sub strip_empty_first_line {
 	if (defined($array->[0]) && $array->[0] =~ /^\s*$/) {
 		shift(@$array); # Throw away the first line
 	}
+
+	return 1;
 }


### PR DESCRIPTION
I ran all of `header_clean.pl` through perlcritic.com on level 4 stern (anything less was WAY too picky) and it found one error: a sub without a return value. This sub operates pass-by-reference so it won't affect anything, but it will make Perl critic happy.