### PR TITLE
Do not sneak in another dash/plus in format_diff_header

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -35,8 +35,8 @@ git_index_line_pattern="^($color_code_regex)index .*"
 format_diff_header () {
   # simplify the unified patch diff header
     $SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//;}" \
-    | $SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\${NL}\1\-\-\-\-\5/g" \
-    | $SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\+\5\\${NL}\1$(print_horizontal_rule)/g"
+    | $SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\${NL}\1---\5/g" \
+    | $SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1+++\5\\${NL}\1$(print_horizontal_rule)/g"
 }
 
 print_horizontal_rule () {

--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -35,11 +35,6 @@ while (my $line = <>) {
 		next;
 	}
 
-	# Mark empty line with a red/green box indicating addition/removal
-	if ($mark_empty_lines) {
-		$line = mark_empty_line($line);
-	}
-
 	######################
 	# End pre-processing
 	######################
@@ -130,6 +125,11 @@ while (my $line = <>) {
 	# Just a regular line, print it out #
 	#####################################
 	} else {
+		# Mark empty line with a red/green box indicating addition/removal
+		if ($mark_empty_lines) {
+			$line = mark_empty_line($line);
+		}
+
 		# Remove the correct number of leading " " or "+" or "-"
 		if ($strip_leading_indicators) {
 			$line = strip_leading_indicators($line,$columns_to_remove);

--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -40,11 +40,6 @@ while (my $line = <>) {
 		$line = mark_empty_line($line);
 	}
 
-	# Remove the correct number of leading " " or "+" or "-"
-	if ($strip_leading_indicators) {
-		$line = strip_leading_indicators($line,$columns_to_remove);
-	}
-
 	######################
 	# End pre-processing
 	######################
@@ -60,12 +55,12 @@ while (my $line = <>) {
 	########################################
 	# Find the first file: --- a/README.md #
 	########################################
-	} elsif ($line =~ /^$ansi_color_regex---* (\w\/)?(.+?)(\e|\t|$)/) {
+	} elsif ($line =~ /^$ansi_color_regex--- (\w\/)?(.+?)(\e|\t|$)/) {
 		$file_1 = $5;
 
 		# Find the second file on the next line: +++ b/README.md
 		my $next = <>;
-		$next    =~ /^$ansi_color_regex\+\+\+* (\w\/)?(.+?)(\e|\t|$)/;
+		$next    =~ /^$ansi_color_regex\+\+\+ (\w\/)?(.+?)(\e|\t|$)/;
 		if ($1) {
 			print $1; # Print out whatever color we're using
 		}
@@ -135,6 +130,10 @@ while (my $line = <>) {
 	# Just a regular line, print it out #
 	#####################################
 	} else {
+		# Remove the correct number of leading " " or "+" or "-"
+		if ($strip_leading_indicators) {
+			$line = strip_leading_indicators($line,$columns_to_remove);
+		}
 		print $line;
 	}
 


### PR DESCRIPTION
And especially do not match with `*` for this, which might trigger false
positives.

This moves the removal of leading +/- down to where those lines are
printed, instead of applying it globally to the input.

Ref: https://github.com/so-fancy/diff-so-fancy/commit/2f743f07941e744b2f24218dc422f26512823549#commitcomment-16952151

No new tests, but maybe I can get one for 10 innernet points from @scottchiefbaker? :) (https://github.com/so-fancy/diff-so-fancy/commit/2f743f07941e744b2f24218dc422f26512823549#commitcomment-16953657)