### PR TITLE
Fix handling lines starting with dashes as file header

### DIFF
--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -23,6 +23,7 @@ my $columns_to_remove = 0;
 my ($file_1,$file_2);
 my $last_file_seen = "";
 my $i = 0;
+my $in_hunk = 0;
 
 while (my $line = <>) {
 
@@ -57,10 +58,11 @@ while (my $line = <>) {
 	if ($line =~ /^${ansi_color_regex}diff --(git|cc) (.*?)(\s|\e|$)/) {
 		$last_file_seen = $5;
 		$last_file_seen =~ s|a/||; # Remove a/
+		$in_hunk = 0;
 	########################################
 	# Find the first file: --- a/README.md #
 	########################################
-	} elsif ($line =~ /^$ansi_color_regex---* (\w\/)?(.+?)(\e|\t|$)/) {
+	} elsif (!$in_hunk && $line =~ /^$ansi_color_regex---* (\w\/)?(.+?)(\e|\t|$)/) {
 		$file_1 = $5;
 
 		# Find the second file on the next line: +++ b/README.md
@@ -94,6 +96,7 @@ while (my $line = <>) {
 	# Check for "@@ -3,41 +3,63 @@" syntax #
 	########################################
 	} elsif ($change_hunk_indicators && $line =~ /^${ansi_color_regex}(@@@* .+? @@@*)(.*)/) {
+		$in_hunk = 1;
 		my $hunk_header    = $4;
 		my $remain         = bleach_text($5);
 		$columns_to_remove = (char_count(",",$hunk_header)) - 1;

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -51,3 +51,8 @@ if begin[m"
   assert_line --index 1 --partial "modified: fish/functions/ls.fish"
   assert_line --index 2 --partial "[1;33m─────"
 }
+
+@test "Leading dashes are not handled as modified" {
+  output=$( load_fixture "leading-dashes" | $diff_so_fancy )
+  refute_output --partial "modified: Callback"
+}

--- a/test/fixtures/leading-dashes.diff
+++ b/test/fixtures/leading-dashes.diff
@@ -1,0 +1,13 @@
+diff --git i/lib/awful/widget/keyboardlayout.lua w/lib/awful/widget/keyboardlayout.lua
+index f9142b8..b6e8ce0 100644
+--- i/lib/awful/widget/keyboardlayout.lua
++++ w/lib/awful/widget/keyboardlayout.lua
+@@ -113,7 +113,7 @@ keyboardlayout.xkeyboard_country_code = {
+     ["za"] = true,    -- South Africa
+ }
+ 
+--- Callback for updaing current layout
++-- Callback for updating current layout.
+ local function update_status (self)
+     self._current = awesome.xkb_get_layout_group();
+     local text = ""


### PR DESCRIPTION
Use a global state ($in_hunk) to only look for `---`-lines before (and
not in) the actual hunk.