### PR TITLE
Fix Use of uninitialized $value in substitution (s///)

### DIFF
--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -212,10 +212,11 @@ sub git_config {
 
 	my $raw = {};
 	foreach my $line (@$out) {
-		my ($key,$value) = split("=",$line,2);
-		$value =~ s/\s+$//;
-
-		$raw->{$key} = $value;
+		if ($line =~ /=/) {
+			my ($key,$value) = split("=",$line,2);
+			$value =~ s/\s+$//;
+			$raw->{$key} = $value;
+		}
 	}
 
 	# If we're given a search key return that, else return the hash


### PR DESCRIPTION
Got the following error since `0.9.0`:
```
$ git diff
Use of uninitialized value $value in substitution (s///)
at /usr/local/lib/node_modules/diff-so-fancy/lib/diff-so-fancy.pl line 216.
```
This attempts to fix it, by only assigning `$raw->{$key}` if `$value` has a value.