### PR TITLE
Properly display binary file modifications

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -15,34 +15,12 @@ get_script_dir () {
   echo "$dir"
 }
 
-# find my sed
-hash gsed 2> /dev/null && SED=gsed || SED=sed
-
 # find my diff-highlight
 if hash diff-highlight 2> /dev/null; then
   diff_highlight=diff-highlight
 else
   diff_highlight="$(get_script_dir)/third_party/diff-highlight/diff-highlight"
 fi
-
-CSI=$'\x1b\['
-NL="
-"
-color_code_regex="(${CSI}([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"
-
-git_index_line_pattern="^($color_code_regex)index .*"
-
-print_horizontal_rule () {
-  let width="$(tput cols)"
-
-  if [[ $(uname -s) =~ (MINGW32*|MSYS*) ]]; then
-    width=$(( width - 1 ))
-  fi
-
-  # echo -n '─' | hexdump -C
-  local -r dash=$( printf "%b" "\xe2\x94\x80" )
-  printf "%*s\n" "$width" | $SED "s/ /${dash}/g"
-}
 
 print_header_clean () {
   "$(get_script_dir)/lib/diff-so-fancy.pl"

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -32,13 +32,6 @@ color_code_regex="(${CSI}([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"
 
 git_index_line_pattern="^($color_code_regex)index .*"
 
-format_diff_header () {
-  # simplify the unified patch diff header
-    $SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//;}" \
-    | $SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\${NL}\1---\5/g" \
-    | $SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1+++\5\\${NL}\1$(print_horizontal_rule)/g"
-}
-
 print_horizontal_rule () {
   let width="$(tput cols)"
 
@@ -59,5 +52,4 @@ print_header_clean () {
 # shellcheck disable=SC2002
 cat $input \
   | $diff_highlight \
-  | format_diff_header \
   | print_header_clean

--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -121,6 +121,12 @@ while (my $line = <>) {
 	######################################
 	} elsif ($remove_file_delete_header && $line =~ /^${ansi_color_regex}deleted file mode/) {
 		# Don't print the line (i.e. remove it from the output);
+	######################################
+	# Look for binary file changes
+	######################################
+	} elsif ($line =~ /Binary files \w\/(.+?) and \w\/(.+?) differ/) {
+		print "${horizontal_color}modified: $2 (binary)\n";
+		print horizontal_rule($horizontal_color);
 	#####################################################
 	# Check if we're changing the permissions of a file #
 	#####################################################

--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -32,7 +32,7 @@ my $in_hunk = 0;
 while (my $line = <>) {
 
 	######################################################
-	# Pre-process the line before we do any other markup
+	# Pre-process the line before we do any other markup #
 	######################################################
 
 	# If the first line of the input is a blank line, skip that
@@ -41,11 +41,14 @@ while (my $line = <>) {
 	}
 
 	######################
-	# End pre-processing
+	# End pre-processing #
 	######################
 
 	#######################################################################
 
+	####################################################################
+	# Look for git index and replace it horizontal line (header later) #
+	####################################################################
 	if ($line =~ /^${ansi_color_regex}index /) {
 		# Print the line color and then the actual line
 		$horizontal_color = $1;
@@ -91,6 +94,7 @@ while (my $line = <>) {
 			print "$file_1 -> $file_2\n";
 		}
 
+		# Print out the bottom horizontal line of the header
 		print horizontal_rule($horizontal_color);
 	########################################
 	# Check for "@@ -3,41 +3,63 @@" syntax #
@@ -172,6 +176,7 @@ sub parse_hunk_header {
 	return ($o_ofs, $o_cnt, $n_ofs, $n_cnt);
 }
 
+# Mark the first char of an empty line
 sub mark_empty_line {
 	my $line = shift();
 
@@ -184,6 +189,7 @@ sub mark_empty_line {
 	return $line;
 }
 
+# String to boolean
 sub boolean {
 	my $str = shift();
 	$str    = trim($str);
@@ -340,6 +346,7 @@ sub char_count {
 	return $ret;
 }
 
+# Remove all ANSI codes from a string
 sub bleach_text {
 	my $str = shift();
 	$str    =~ s/\e\[\d*(;\d+)*m//mg;
@@ -347,6 +354,7 @@ sub bleach_text {
 	return $str;
 }
 
+# Remove all trailing and leading spaces
 sub trim {
 	my $s = shift();
 	if (!$s) { return ""; }
@@ -355,7 +363,7 @@ sub trim {
 	return $s;
 }
 
-
+# Print a line of em-dash or line-drawing chars the full width of the screen
 sub horizontal_rule {
 	my $color = $_[0] || "";
 	my $width = `tput cols`;

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -56,3 +56,9 @@ if begin[m"
   output=$( load_fixture "leading-dashes" | $diff_so_fancy )
   refute_output --partial "modified: Callback"
 }
+
+@test "Handle binary modifications" {
+  output=$( load_fixture "binary-modified" | $diff_so_fancy )
+  run printf "%s" "$output"
+  assert_line --index 1 --partial "modified: cancel.png (binary)";
+}

--- a/test/fixtures/binary-modified.diff
+++ b/test/fixtures/binary-modified.diff
@@ -1,0 +1,21 @@
+[1;33mdiff --git a/cancel.png b/cancel.png[m
+[1;33mindex 667e10c..06fc49c 100644[m
+Binary files a/cancel.png and b/cancel.png differ
+[1;33mdiff --git a/diff-so-fancy b/diff-so-fancy[m
+[1;33mindex 0f2911c..5811717 100755[m
+[1;33m--- a/diff-so-fancy[m
+[1;33m+++ b/diff-so-fancy[m
+[1;35m@@ -32,13 +32,6 @@[m [mcolor_code_regex="(${CSI}([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"[m
+ [m
+ git_index_line_pattern="^($color_code_regex)index .*"[m
+ [m
+[1;31m-format_diff_header () {[m
+[1;31m-  # simplify the unified patch diff header[m
+[1;31m-    $SED -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//;}" \[m
+[1;31m-    | $SED -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\${NL}\1---\5/g" \[m
+[1;31m-    | $SED -E "s/^($color_code_regex)\+\+\+(.*)$/\1+++\5\\${NL}\1$(print_horizontal_rule)/g"[m
+[1;31m-}[m
+[1;31m-[m
+ print_horizontal_rule () {[m
+   let width="$(tput cols)"[m
+ [m


### PR DESCRIPTION
This also moves `horizontal_rule()` to Perl. Three less calls to sed so it should be quicker too.