### PR TITLE
don't print characters that we know will be incompatible with less(1)

### DIFF
--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -4,6 +4,7 @@ load 'test_helper/bats-support/load'
 load 'test_helper/bats-assert/load'
 load 'test_helper/util'
 
+set_env
 
 # bats fails to handle our multiline result, so we save to $output ourselves
 output=$( load_fixture "ls-function" | $diff_so_fancy )
@@ -50,6 +51,18 @@ if begin[m"
   assert_line --index 0 --partial "[1;33m─────"
   assert_line --index 1 --partial "modified: fish/functions/ls.fish"
   assert_line --index 2 --partial "[1;33m─────"
+}
+
+# see https://git.io/vrOF4
+@test "Should not show unicode bytes in hex if missing LC_*/LANG _and_ piping the output" {
+  unset LESSCHARSET LESSCHARDEF LC_ALL LC_CTYPE LANG
+  # pipe to cat(1) so we don't open stdout
+  header=$( printf "%s" "$(load_fixture "ls-function" | $diff_so_fancy | cat)" | head -n3 )
+  run printf "%s" "$header"
+  assert_line --index 0 --partial "[1;33m-----"
+  assert_line --index 1 --partial "modified: fish/functions/ls.fish"
+  assert_line --index 2 --partial "[1;33m-----"
+  set_env # reset env
 }
 
 @test "Leading dashes are not handled as modified" {

--- a/test/test_helper/util.bash
+++ b/test/test_helper/util.bash
@@ -6,6 +6,10 @@ load_fixture() {
   cat "$BATS_TEST_DIRNAME/fixtures/${name}.diff"
 }
 
+set_env() {
+  export LC_CTYPE="en_US.UTF-8"
+}
+
 
 # applying colors so ANSI color values will match
 # FIXME: not everyone will have these set, so we need to test for that.


### PR DESCRIPTION
This is very corner-case and maybe not that interesting. (see https://github.com/so-fancy/diff-so-fancy/issues/72#issuecomment-219591245)

![screenshot 2016-05-24 at 19 53 48](https://cloud.githubusercontent.com/assets/6705160/15514418/3edd68f6-21e9-11e6-818b-8327b59fe102.png)

<sup>(the dashes do not overflow like in the screenshot, created a new pane after)</sup>