### PR TITLE
Fix up 'dsf' git alias example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,9 @@ git diff --color | diff-so-fancy
 git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
 ```
 
-However, if you'd prefer to do the fanciness on-demand with `git dsf`, drop an alias in your `~/.gitconfig`:
+However, if you'd prefer to do the fanciness on-demand with `git dsf`, add an alias to your git config:
 ```shell
-dsf = "!f() { [ \"$GIT_PREFIX\" != \"\" ] && cd "$GIT_PREFIX"; git diff --color $@ | diff-so-fancy | less --tabs=4 -RFX; }; f"
+git config --global alias.dsf '!f() { [ -z "$GIT_PREFIX" ] || cd "$GIT_PREFIX" && git diff --color "$@" | diff-so-fancy | less --tabs=4 -RFX; }; f'
 ```
 
 ## Install


### PR DESCRIPTION
- Fix quoting around GIT_PREFIX
- Use && to fail early if the cd does
- Use `git config --global alias.dsf`, which git recommends over
  hand-editing .gitconfig (and makes it easy to adapt the command to
  per-repository configs by dropping --global)