### PR TITLE
issues35 update readme with interactive.diffFilter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,11 @@ However, if you'd prefer to do the fanciness on-demand with `git dsf`, drop an a
 dsf = "!f() { [ \"$GIT_PREFIX\" != \"\" ] && cd "$GIT_PREFIX"; git diff --color $@ | diff-so-fancy | less --tabs=4 -RFX; }; f"
 ```
 
+As of **git 2.9** you can also fancy up the output of interactive patch selection (`git add/checkout/stash/reset --patch`). This requires the `--patch-mode` option to ensure everything lines up. Apply it like this:
+```shell
+git config --global interactive.diffFilter "diff-so-fancy --patch-mode | less --tabs=4 -RFX"
+```
+
 ## Install
 
 For convenience, the recommended installation is via NPM. If you'd prefer, you may choose to do a [manual installation](#manual-install) instead.


### PR DESCRIPTION
Note in the readme about the resolution of https://github.com/so-fancy/diff-so-fancy/issues/35

In git 2.9 you can now use diff-so-fancy in `git add --patch`.
