### PR TITLE
Properly handle latin1 encoded text

### DIFF
--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -4,8 +4,11 @@ use strict;
 use warnings FATAL => 'all';
 use File::Basename;
 
-use utf8;
+# Set the input (STDIN) as UTF8, but don't give warnings about unknown chars
 use open qw(:std :utf8); # http://stackoverflow.com/a/519359
+no warnings 'utf8';
+
+# Set the output to always be UTF8
 binmode STDOUT,':utf8';
 
 my $remove_file_add_header    = 1;

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -81,3 +81,9 @@ if begin[m"
   run printf "%s" "$output"
   assert_line --index 5 --partial "åäöç"
 }
+
+@test "Handle latin1 encoding sanely" {
+  output=$( load_fixture "latin1" | $diff_so_fancy )
+  # Make sure the output contains SOME of the english text (i.e. it doesn't barf on the whole line)
+  assert_output --partial "saw he conqu"
+}

--- a/test/fixtures/latin1.diff
+++ b/test/fixtures/latin1.diff
@@ -1,0 +1,8 @@
+[38;5;227mdiff --git a/test.txt b/test.txt[m
+[38;5;227mindex 5836369..51ccf71 100644[m
+[38;5;227m--- a/test.txt[m
+[38;5;227m+++ b/test.txt[m
+[1;35m@@ -1,6 +1 @@[m
+[38;5;9m-Ã©[m
+[38;5;9m-[m
+[38;5;10m+[m[38;5;10mHé camé hé saw he conquéréd[m


### PR DESCRIPTION
We assume input is UTF8 (we have to), so when input is latin1 it causes Perl to barf on an unknown char mapping. This disables warnings so the chars get imported as their hex codes like <E9>. It's not a perfect solution, but it will get us by.