### PR TITLE
Fix for old Perl 5.8

### DIFF
--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -160,7 +160,7 @@ while (my $line = <>) {
 # Courtesy of github.com/git/git/blob/ab5d01a/git-add--interactive.perl#L798-L805
 sub parse_hunk_header {
 	my ($line) = @_;
-	my ($o_ofs, $o_cnt, $n_ofs, $n_cnt) = $line =~ /^@@+(?: -(\d+)(?:,(\d+))?)+ \+(\d+)(?:,(\d+))? @@+/;
+	my ($o_ofs, $o_cnt, $n_ofs, $n_cnt) = $line =~ /^\@\@+(?: -(\d+)(?:,(\d+))?)+ \+(\d+)(?:,(\d+))? \@\@+/;
 	$o_cnt = 1 unless defined $o_cnt;
 	$n_cnt = 1 unless defined $n_cnt;
 	return ($o_ofs, $o_cnt, $n_ofs, $n_cnt);

--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -212,8 +212,8 @@ sub boolean {
 
 # Fetch a textual item from the git config
 sub git_config {
-	my $search_key    = lc($_[0] // "");
-	my $default_value = lc($_[1] // "");
+	my $search_key    = lc($_[0] || "");
+	my $default_value = lc($_[1] || "");
 
 	my $out = git_config_raw();
 
@@ -233,7 +233,7 @@ sub git_config {
 
 	# If we're given a search key return that, else return the hash
 	if ($search_key) {
-		return $raw->{$search_key} // $default_value;
+		return $raw->{$search_key} || $default_value;
 	} else {
 		return $raw;
 	}
@@ -300,7 +300,7 @@ sub get_git_config_hash {
 
 		my $last = pop @path;
 		my $p = \%hash;
-		$p = $p->{$_} //= {} for @path;
+		$p = $p->{$_} ||= {} for @path;
 		$p->{$last} = $value;
 	}
 


### PR DESCRIPTION
The diff in #175 is insufficient for Perl 5.8.  This patches additional `//` => `||` and escaping `@` in regexp.