### PR TITLE
Update recommended pre-seeded search pattern

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ git --no-pager diff
 
 #### Moving around in the diff
 
-You can pre-seed your `less` pager with a search pattern, so you can move between files with `n`/`p` keys. Add `--pattern='^(added|deleted|modified): '` to the end of the less flags for your git pager config.
+You can pre-seed your `less` pager with a search pattern, so you can move between files with `n`/`p` keys. Add `--pattern='^(Date|added|deleted|modified): '` to the end of the less flags for your git pager config.
 
 ## History
 


### PR DESCRIPTION
The old recommended pre-seeded search pattern for less would cause "git
show" to jump past the commit message, going straight to the file. This
change would prevent that (mis)behavior, without hindering the
pattern's usefulness.