### PR TITLE
Add setting to allow disabling of unicode ruler

### DIFF
--- a/lib/diff-so-fancy.pl
+++ b/lib/diff-so-fancy.pl
@@ -11,12 +11,13 @@ no warnings 'utf8';
 # Set the output to always be UTF8
 binmode STDOUT,':encoding(UTF-8)';
 
-my $remove_file_add_header    = 1;
-my $remove_file_delete_header = 1;
-my $clean_permission_changes  = 1;
-my $change_hunk_indicators    = git_config_boolean("diff-so-fancy.changeHunkIndicators","true");
-my $strip_leading_indicators  = git_config_boolean("diff-so-fancy.stripLeadingSymbols","true");
-my $mark_empty_lines          = git_config_boolean("diff-so-fancy.markEmptyLines","true");
+my $remove_file_add_header     = 1;
+my $remove_file_delete_header  = 1;
+my $clean_permission_changes   = 1;
+my $change_hunk_indicators     = git_config_boolean("diff-so-fancy.changeHunkIndicators","true");
+my $strip_leading_indicators   = git_config_boolean("diff-so-fancy.stripLeadingSymbols","true");
+my $mark_empty_lines           = git_config_boolean("diff-so-fancy.markEmptyLines","true");
+my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRuler","true");
 
 #################################################################################
 
@@ -391,7 +392,7 @@ sub horizontal_rule {
 	#my $dash = "\x{2014}";
 	# BOX DRAWINGS LIGHT HORIZONTAL http://www.fileformat.info/info/unicode/char/2500/index.htm
 	my $dash;
-	if (should_print_unicode()) {
+	if ($use_unicode_dash_for_ruler && should_print_unicode()) {
 		$dash = "\x{2500}";
 	} else {
 		$dash = "-";

--- a/readme.md
+++ b/readme.md
@@ -84,12 +84,18 @@ Simplify git header chunks to a more human readable format.
 
 Should the pesky `+` or `-` at line-start be removed.
 
+### useUnicodeRuler
+
+Should the horizonal line above and below the name of the changed file be displayed using unicode.  
+Try setting this to `false` if those lines are displayed to long to fit your screen.
+
 By default all the configs are true. You can turn any off by running:
 
 ```
 git config --bool --global diff-so-fancy.markEmptyLines false
 git config --bool --global diff-so-fancy.changeHunkIndicators false
 git config --bool --global diff-so-fancy.stripLeadingSymbols false
+git config --bool --global diff-so-fancy.useUnicodeRuler false
 ```
 
 To reset them to default (`true`):
@@ -98,6 +104,7 @@ To reset them to default (`true`):
 git config --unset --global diff-so-fancy.markEmptyLines
 git config --unset --global diff-so-fancy.changeHunkIndicators
 git config --unset --global diff-so-fancy.stripLeadingSymbols
+git config --unset --global diff-so-fancy.useUnicodeRuler
 ```
 
 ## Pro-tips

--- a/readme.md
+++ b/readme.md
@@ -86,8 +86,8 @@ Should the pesky `+` or `-` at line-start be removed.
 
 ### useUnicodeRuler
 
-Should the horizonal line above and below the name of the changed file be displayed using unicode.  
-Try setting this to `false` if those lines are displayed to long to fit your screen.
+By default the separator for the file header uses unicode line drawing characters.  
+If this is causing output errors on your terminal set this to `false` to use ASCII characters instead.
 
 By default all the configs are true. You can turn any off by running:
 


### PR DESCRIPTION
This commit adds a single setting to allow users
to disable the use of the unicode em-dash that is being used
as a horizonal ruler character for marking the changed filename.

It defaults to the current behaviour of using em-dash.

Setting `diff-so-fancy.useUnicodeRuler` to `false` will use a simple
dash (minus sign) instead.

This fixes a problem I have when using diff-so-fancy with my iTerm2 settings.
In my case the ruler would span multiple lines:
<img width="532" alt="diff-so-fancy-broken-iterm2" src="https://cloud.githubusercontent.com/assets/100459/16867768/0478b612-4a74-11e6-9cc8-affc0361e777.png">

Cheers!
