### PR TITLE
Improve "pro-tips" documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,16 @@ Sometimes you will want to bypass diff-so-fancy. Use `--no-pager` for that:
 git --no-pager diff
 ```
 
+#### Raw patches
+
+As a shortcut for a 'normal' diff to save as a patch for emailing or later
+application, it may be helpful to configure an alias:
+```ini
+[alias]
+    patch = --no-pager diff --no-color
+```
+which can then be used as `git patch > changes.patch`.
+
 #### Moving around in the diff
 
 You can pre-seed your `less` pager with a search pattern, so you can move

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,12 @@ git --no-pager diff
 
 #### Moving around in the diff
 
-You can pre-seed your `less` pager with a search pattern, so you can move between files with `n`/`p` keys. Add `--pattern='^(Date|added|deleted|modified): '` to the end of the less flags for your git pager config.
+You can pre-seed your `less` pager with a search pattern, so you can move
+between files with `n`/`p` keys:
+```ini
+[pager]
+    diff = diff-so-fancy | less --tabs=4 -RFX --pattern'^(Date|added|deleted|modified): '
+```
 
 ## History
 


### PR DESCRIPTION
- Explicitly limits suggestion to over-eager load a search for navigation purposes to diffs (closes #173).
- Adds a new tip for `patch` alias to render DSF-less `.patch`es.