### PR TITLE
Disable fancification when redirecting output to a file

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 [[ $# -ge 1 ]] && [[ -f "$1" ]] && input="$1" || input="-"
+[[ $# -ge 1 ]] && less_opts="${*:1}" || less_opts=
 
 get_script_dir () {
   src="${BASH_SOURCE[0]}"
@@ -26,8 +27,11 @@ print_header_clean () {
   "$(get_script_dir)/lib/diff-so-fancy.pl"
 }
 
-# run it.
-# shellcheck disable=SC2002
-cat $input \
-  | $diff_highlight \
-  | print_header_clean
+if [[ -t 1 ]]; then
+    # run it.
+    # shellcheck disable=SC2002
+    cat $input | $diff_highlight | print_header_clean | less -R $less_opts
+else
+    # stdout is not going to a terminal; probably a patch file
+    cat $input
+fi

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -27,11 +27,13 @@ print_header_clean () {
   "$(get_script_dir)/lib/diff-so-fancy.pl"
 }
 
-if [[ -t 1 ]]; then
+FD_is_pipe=$(perl -e 'exit(-p STDOUT ? 0 : 1);')
+FD_is_terminal=$(test -t 1)
+if $FD_is_terminal || $FD_is_pipe; then
     # run it.
     # shellcheck disable=SC2002
     cat $input | $diff_highlight | print_header_clean | less -R $less_opts
 else
-    # stdout is not going to a terminal; probably a patch file
+    # stdout is not going to a terminal or pipe; probably a patch file
     cat $input
 fi

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@ your diffs' appearances.
 
 * Output will not be in standard patch format, but will be readable.
 * No pesky `+` or `-` at line-start, making for easier copy-paste.
+* Standard [Unified Format](http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html)
+ is reverted to on redirection, for GNU-compatible `.patch` files
 
 ## Screenshot
 
@@ -21,13 +23,22 @@ git diff --color | diff-so-fancy
 
 **But**, you'll probably want to fancify all your diffs. Run this so `git diff` will use it:
 ```shell
-git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
+git config --global core.pager "diff-so-fancy"
 ```
+
+If your existing pager is `less` with some other options, you can add them too, e.g.
+```shell
+git config --global core.pager "diff-so-fancy --tabs=4 -FX"
+```
+diff-so-fancy requires `--RAW-CONTROL-CHARS` (`-R`) for fancy colouring; you don't need to supply this.
+
+Other pagers are not currently supported; piping to e.g. `vim -` will render the
+same as without diff-so-fancy.
 
 However, if you'd prefer to do the fanciness on-demand with `git dsf`, add an alias to your `~/.gitconfig` by running:
 ```shell
 git config --global alias.dsf '!f() { [ -z "$GIT_PREFIX" ] || cd "$GIT_PREFIX" '\
-'&& git diff --color "$@" | diff-so-fancy  | less --tabs=4 -RFX; }; f'
+'&& git diff --color "$@" | diff-so-fancy; }; f'
 ```
 
 ## Install
@@ -119,13 +130,13 @@ git --no-pager diff
 
 #### Raw patches
 
-As a shortcut for a 'normal' diff to save as a patch for emailing or later
-application, it may be helpful to configure an alias:
-```ini
-[alias]
-    patch = --no-pager diff --no-color
+Fancification is disabled when diff-so-fancy's output is redirected, so if you
+want to save a 'normal' [Unified Format](http://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html)
+diff, you don't need to do anything different.
+```shell
+git diff > changes.patch # no colours; standard format
+git diff # fancy colours and formatting
 ```
-which can then be used as `git patch > changes.patch`.
 
 #### Moving around in the diff
 
@@ -133,7 +144,7 @@ You can pre-seed your `less` pager with a search pattern, so you can move
 between files with `n`/`p` keys:
 ```ini
 [pager]
-    diff = diff-so-fancy | less --tabs=4 -RFX --pattern'^(Date|added|deleted|modified): '
+    diff = diff-so-fancy --pattern'^(Date|added|deleted|modified): '
 ```
 
 ## History


### PR DESCRIPTION
This commit aims to better support standard patch files, by
disabling colours and header removal when the stdout file
descriptor is opened on a terminal.

The assumption is that if this is _not_ the case, it is most
likely that the diff output is being redirected to a .patch file,
for emailing or some other medium in which fancified output may
be confusing, and not compatible with standard tools.

We do this by internalising `less`, providing the bare minimum
`--RAW-CONTROL-CHARS` option required for diff-so-fancy to operate
as expected, and appending any user-supplied options.

~~This is actually _NOT_ a breaking change.~~ \* `less` performs a
similar test, and exits leaving its input on stdout. This means
that a user who upgrades but keeps `diff-so-fancy | less $OPTS`
will ~~still see the new behaviour; keeping~~ keep their existing `less`
configuration. (The `-R` requirement is not new; this hypothetical
user must have had at least `OPTS=R`.)

This commit closes #181.
- See [my comment below](https://github.com/so-fancy/diff-so-fancy/pull/190#issuecomment-238027844). It's not breaking, for now, but I think it would be a good idea to - for reasons outlined in 5582a58.
