### PR TITLE
Mercurial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,24 @@ Installation is as simple as downloading the [diff-so-fancy](https://raw.githubu
 
 ## Usage
 
+### Git
+
 Configure git to use `diff-so-fancy` for all diff output:
 ```shell
 git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
+```
+
+### Mercurial
+
+```shell
+hg config --edit
+```
+
+Add
+
+```
+[pager]
+pager = diff-so-fancy | less --tabs=4 -RFX
 ```
 
 ### Improved colors for the highlighted bits

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -148,6 +148,16 @@ sub do_dsf_stuff {
 			$last_file_seen = $5;
 			$last_file_seen =~ s|^\w/||; # Remove a/ (and handle diff.mnemonicPrefix).
 			$in_hunk = 0;
+		###################################################################
+		# Mercurial prints git's equivalent of diff and index in one line #
+		###################################################################
+		} elsif ($line =~ /^${ansi_color_regex}diff -r (.*?)(\s|\e|$)/) {
+			$meta_color = $1 || DiffHighlight::color_config('color.diff.meta',"\e[38;5;11m");
+			print horizontal_rule($meta_color);
+
+			$last_file_seen = $5;
+			$last_file_seen =~ s|^\w/||; # Remove a/ (and handle diff.mnemonicPrefix).
+			$in_hunk = 0;
 		########################################
 		# Find the first file: --- a/README.md #
 		########################################


### PR DESCRIPTION
This will help with Mercurial compatibility – it doesn't output `index` line, and `diff-so-fancy` depends on it to draw the first horizontal line.

All `bats test`s pass.

Fixes #186
