### PR TITLE
Fix readme advise about moving around in the diff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ which can then be used as `git patch > changes.patch`.
 #### Moving around in the diff
 
 You can pre-seed your `less` pager with a search pattern, so you can move
-between files with `n`/`p` keys:
+between files with `n`/`N` keys:
 ```ini
 [pager]
     diff = diff-so-fancy | less --tabs=4 -RFX --pattern '^(Date|added|deleted|modified): '


### PR DESCRIPTION
As commented by @samiraguiar in https://github.com/so-fancy/diff-so-fancy/commit/70b91f3cd81b979ca60aef46efd8d8d73caa77de#commitcomment-17975342, moving back up between files is done with `N` , not `p`.