### PR TITLE
Fix README patch alias

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ As a shortcut for a 'normal' diff to save as a patch for emailing or later
 application, it may be helpful to configure an alias:
 ```ini
 [alias]
-    patch = --no-pager diff --no-color
+    patch = !git --no-pager diff --no-color
 ```
 which can then be used as `git patch > changes.patch`.
 


### PR DESCRIPTION
When I set `patch = --no-pager diff --no-color` in my gitconfig and type `git patch`, I have this error:

```
fatal: alias 'patch' changes environment variables
You can use '!git' in the alias to do this.
```

Then, here is a fix.