### PR TITLE
Get the realpath of diff-so-fancy

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -578,7 +578,7 @@ sub find_diff_highlight {
 		$ret = $dh_in_path;
 	# We use the one bundled with d-s-f
 	} else {
-		my $path = dirname($0) . "/third_party/$dh/diff-highlight";
+		my $path = dirname(Cwd::realpath($0)) . "/third_party/$dh/diff-highlight";
 		$ret     = Cwd::realpath($path);
 	}
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -578,8 +578,7 @@ sub find_diff_highlight {
 		$ret = $dh_in_path;
 	# We use the one bundled with d-s-f
 	} else {
-		my $path = dirname(Cwd::realpath($0)) . "/third_party/$dh/diff-highlight";
-		$ret     = Cwd::realpath($path);
+		$ret = dirname(Cwd::realpath($0)) . "/third_party/$dh/diff-highlight";
 	}
 
 	if (!-X $ret) {


### PR DESCRIPTION
`$0` may be a symlink of `diff-so-fancy`, then `dirname($0)` will point to a wrong directory. Use `Cwd::realpath` to figure out the actual path first.