### PR TITLE
Fix curl flags in update-deps.sh

### DIFF
--- a/update-deps.sh
+++ b/update-deps.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -oL "third_party/diff-highlight/diff-highlight" "https://github.com/git/git/raw/master/contrib/diff-highlight/diff-highlight"
-curl -oL "third_party/diff-highlight/README" "https://github.com/git/git/raw/master/contrib/diff-highlight/README"
+curl -Lo "third_party/diff-highlight/diff-highlight" "https://github.com/git/git/raw/master/contrib/diff-highlight/diff-highlight"
+curl -Lo "third_party/diff-highlight/README" "https://github.com/git/git/raw/master/contrib/diff-highlight/README"


### PR DESCRIPTION
After `-o` must follow the output path.
The `-L` should either come before `-o` or after the path.