### PR TITLE
re-enable shellcheck on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ install:
 script:
   - ./bats/bin/bats test/*.bats
   - perlcritic -1 -q --theme freenode diff-so-fancy
+  - shellcheck *.sh

--- a/circle.yml
+++ b/circle.yml
@@ -18,4 +18,4 @@ checkout:
 test:
   override:
     - bats/bin/bats test/*.bats
-    - shellcheck diff-so-fancy update-deps.sh
+    - shellcheck *.sh

--- a/report-bug.sh
+++ b/report-bug.sh
@@ -3,7 +3,7 @@
 clipboard() {
   local copy_cmd
   if [ -n "$PBCOPY_SERVER" ]; then
-    local body="" buffer
+    local body="" # buffer
     body=$(cat)
     # while IFS= read -r buffer; do
     #   body="$body$buffer\n";

--- a/report-bug.sh
+++ b/report-bug.sh
@@ -8,7 +8,7 @@ clipboard() {
     # while IFS= read -r buffer; do
     #   body="$body$buffer\n";
     # done
-    curl $PBCOPY_SERVER --data-urlencode body="$body" >/dev/null 2>&1
+    curl "$PBCOPY_SERVER" --data-urlencode body="$body" >/dev/null 2>&1
     return $?
   fi
   if type putclip >/dev/null 2>&1; then
@@ -32,7 +32,7 @@ clipboard() {
     local copy_cmd="xsel -b"
   fi
   if [ -n "$copy_cmd" ] ;then
-    eval $copy_cmd
+    eval "$copy_cmd"
   else
     echo "clipboard is unavailable" 1>&2
   fi
@@ -40,20 +40,21 @@ clipboard() {
 
 file=${2:-diff.txt}
 
-echo $1 > $file
-eval $1 >> $file
+{
+  echo "$1"
+  eval "$1"
+  echo ""
+  echo ""
+  echo ""
 
-echo "
+  echo "$1 --color"
+  eval "$1 --color"
 
-" >> $file
+  echo "git config pager.diff"
+  eval "git config pager.diff"
 
-echo "$1 --color" >> $file
-eval "$1 --color" >> $file
+  echo "git config pager.show"
+  eval "git config pager.show"
+} > "$file"
 
-echo "git config pager.diff" >> $file
-eval "git config pager.diff" >> $file
-
-echo "git config pager.show" >> $file
-eval "git config pager.show" >> $file
-
-cat $file | base64 | clipboard
+base64 < "$file" | clipboard


### PR DESCRIPTION
it was failing on circleCI: https://circleci.com/gh/so-fancy/diff-so-fancy/404
and just not enabled on travis

So i've flipped it back on in the config, included report-bug.sh and fixed the errors there.

Now we're green on all our CI. \o/