### PR TITLE
Wrap diff_highlight in quotes to avoid err on windows

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -565,7 +565,7 @@ sub filter_stdin_through_diff_highlight {
 	my $dh  = find_diff_highlight();
 
 	# Pipe the STDIN of this to diff-highlight
-	my $pid = open(my $cmd_output, "-|", $dh);
+	my $pid = open(my $cmd_output, "-|", "\"$dh\"");
 
 	return $cmd_output;
 }


### PR DESCRIPTION
Not sure if this is the best solution but fixes the issue(#239) on Windows 8.

Ran tests using mintty on cmder. 1 test fails:
```
not ok 9 header format uses a native line-drawing character
# (from function `assert_line' in file test/test_helper/bats-assert/src/assert.bash, line 468,
#  in test file test/diff-so-fancy.bats, line 51)
#   `assert_line --index 0 --partial "─────"' failed
#
# -- line does not contain substring --
# index     : 0
# substring : ─────
# line      : --------------------------------------------------------------------------------
# --
#
```
But **all** tests fail on the master branch.

Also, not sure if this can cause any issue on other platforms.

Closes #239