### PR TITLE
update-deps: Fix DiffHighlight's URL and refactor

### DIFF
--- a/update-deps.sh
+++ b/update-deps.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-curl -Lo "third_party/diff-highlight/diff-highlight" "https://github.com/git/git/raw/master/contrib/diff-highlight/diff-highlight"
-curl -Lo "third_party/diff-highlight/README" "https://github.com/git/git/raw/master/contrib/diff-highlight/README"
+DIFFHIGHLIGHT_RAW_URL_BASE="https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight"
+DIFFHIGHLIGHT_FILES=( "DiffHighlight.pm" "README" )
+
+for file in "${DIFFHIGHLIGHT_FILES[@]}";
+do
+  url="$DIFFHIGHLIGHT_RAW_URL_BASE/$file"
+  echo "$url"
+  curl -#Lo "lib/$file" "$url"
+done


### PR DESCRIPTION
Seems like I'm the only one who tries to use `update-deps.sh`, huh?
This time there were two different problems:
1. `diff-highlight` was made a `.pm` so the old URL doesn't point to a valid endpoint.
2. `diff-highlight`/`DiffHighlight` is no longer expected to be found locally in `third-party`, but in `lib`. I guess that's some `perl` or at least `fatpack` convention for where local modules should be placed.

A word of warning, though: Unlike this repo's version of [`DiffHighlight`](/so-fancy/diff-so-fancy/blob/master/lib/DiffHighlight.pm) , the current git-contrib version of [`DiffHighlight`](/git/git/blob/master/contrib/diff-highlight/DiffHighlight.pm) doesn't `use Encode`.
This means that after an update & rebuild (fatpack), `diff-so-fancy` will fail ([here](/so-fancy/diff-so-fancy/blob/master/diff-so-fancy#L474)) unless it has its own `use Encode`.

_Source: It bit me._ :/
