### PR TITLE
[Windows] Fix incorrect directory listing for UNIX emulated perl on Windows

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -4,10 +4,10 @@ my $VERSION = "1.2.0";
 
 #################################################################################
 
-use Cwd qw(abs_path);                   # For realpath()
-use File::Basename;                     # for dirname
-use Encode;                             # For handling UTF8 stuff
-use lib dirname(abs_path($0)) . "/lib"; # Add the local lib/ to @INC
+use File::Spec;                                     # For catdir
+use File::Basename;                                 # For dirname
+use Encode;                                         # For handling UTF8 stuff
+use lib dirname(File::Spec->catdir($0)) . "/lib";   # Add the local lib/ to @INC
 use DiffHighlight;
 
 use strict;


### PR DESCRIPTION
This will close #265 

Using UNIX emulated perl on Windows (which many people use) will cause `diff-so-fancy` not work because the path resolution is wrong.

This is the output we get from `dirname(abs_path($0)) . "/lib"`:
```
/c/Users/stani/Work/Personal/diff-so-fancy/C:/Users/stani/AppData/Roaming/npm/node_modules/diff-so-fancy/lib
```

Clearly this path is invalid therefore the module `DiffHighlight` is not found. By using `dirname(File::Spec->catdir($0))` we get the correct path.