### PR TITLE
The '--set-defaults' option doesn't work with a dash.

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -43,7 +43,7 @@ if (!$has_stdin) {
 
 	if ($args->{v} || $args->{version}) {
 		die(version());
-	} elsif ($args->{'set-defaults'}) {
+	} elsif ($args->{setdefaults}) {
 		my $ok = set_defaults();
 	} elsif ($args->{colors}) {
 		# We print this to STDOUT so we can redirect to bash to auto-set the colors
@@ -620,7 +620,7 @@ sub usage {
 
 git diff --color | diff-so-fancy # Use d-s-f on one diff
 diff-so-fancy --colors           # View the commands to set the recommended colors
-diff-so-fancy --set-defaults     # Configure git-diff to use diff-so-fancy and suggested colors
+diff-so-fancy --setdefaults     # Configure git-diff to use diff-so-fancy and suggested colors
 
 # Configure git to use d-s-f for *all* diff operations
 git config --global core.pager \"diff-so-fancy | less --tabs=4 -RFX\"\n";


### PR DESCRIPTION
Accessing the "--set-defaults" option with "$args->{'set-defaults'}" doesn't work.  Changing it to "--setdefaults" and accessing it with "$args->{setdefaults}" fixes the issue.

```
coandco@aptserver:~/git/diff-so-fancy-original$ ./diff-so-fancy
Diff-so-fancy: https://github.com/so-fancy/diff-so-fancy
Version      : 1.2.0

Usage:

git diff --color | diff-so-fancy # Use d-s-f on one diff
diff-so-fancy --colors           # View the commands to set the recommended colors
diff-so-fancy --set-defaults     # Configure git-diff to use diff-so-fancy and suggested colors

# Configure git to use d-s-f for *all* diff operations
git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
coandco@aptserver:~/git/diff-so-fancy-original$ ./diff-so-fancy --set-defaults
Missing input on STDIN
coandco@aptserver:~/git/diff-so-fancy-original$ cd ../diff-so-fancy-coandco
coandco@aptserver:~/git/diff-so-fancy-coandco$ ./diff-so-fancy
Diff-so-fancy: https://github.com/so-fancy/diff-so-fancy
Version      : 1.2.0

Usage:

git diff --color | diff-so-fancy # Use d-s-f on one diff
diff-so-fancy --colors           # View the commands to set the recommended colors
diff-so-fancy --setdefaults     # Configure git-diff to use diff-so-fancy and suggested colors

# Configure git to use d-s-f for *all* diff operations
git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
coandco@aptserver:~/git/diff-so-fancy-coandco$ ./diff-so-fancy --setdefaults
coandco@aptserver:~/git/diff-so-fancy-coandco$
```