### PR TITLE
Arbitrary diff improvements

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -186,6 +186,14 @@ sub do_dsf_stuff {
 			$last_file_seen =~ s|^\w/||; # Remove a/ (and handle diff.mnemonicPrefix).
 			$in_hunk = 0;
 		########################################
+		# Look for added / removed files (non git, non -N)
+		########################################
+		} elsif ($line =~ /^${ansi_color_regex}Only in /) {
+			unless ($1) {
+				print get_config_color("meta");
+			}
+			print $line;
+		########################################
 		# Find the first file: --- a/README.md #
 		########################################
 		} elsif (!$in_hunk && $line =~ /^$ansi_color_regex--- (\w\/)?(.+?)(\e|\t|$)/) {

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -172,13 +172,16 @@ sub do_dsf_stuff {
 				$meta_color ||= get_config_color("meta");
 
 			# Git looks like: diff --git a/diff-so-fancy b/diff-so-fancy
-			} elsif ($diff_args =~ /^(?:--git|--cc) (.+?)(\s|\e|$)/) {
-			    $last_file_seen = $1;
+			} elsif ($diff_args =~ /^(--git|--cc) (.+?)(\s|\e|$)/) {
+			    $last_file_seen = $2;
 
-			# Otherwise, last two args are file names.  Assume they have no
-			# spaces, as "a b c" is ambiguous anyway.
+			# Otherwise, there are arbitrary args, but the last two are the
+			# file names.  Assume the names have no spaces, as git output does not
+			# include quotes, so "a b c" is ambiguous anyway.
 			} else {
+				# Strip trailing "reset color" escape sequence
 				$diff_args =~ s/\e.*$//;
+				# Match last two words; capture the first of these
 				$diff_args =~ /([^ ]+) [^ ]+$/;
 				$last_file_seen = $1;
 			}

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -246,6 +246,8 @@ sub do_dsf_stuff {
 
 			if ($1) {
 				print $1; # Print out whatever color we're using
+			} elsif ($manually_color_lines) {
+				print get_config_color("frag");
 			}
 
 			my ($orig_offset, $orig_count, $new_offset, $new_count) = parse_hunk_header($hunk_header);
@@ -808,6 +810,8 @@ sub color {
 		if ($str eq "meta") {
 			# Default ANSI yellow
 			$ret = DiffHighlight::color_config('color.diff.meta', color(11));
+		} elsif ($str eq "frag") {
+			$ret = DiffHighlight::color_config('color.diff.frag', color('bold') . color(13));
 		} elsif ($str eq "reset") {
 			$ret = color("reset");
 		} elsif ($str eq "add_line") {

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -163,16 +163,24 @@ sub do_dsf_stuff {
 		#########################
 		# Look for the filename #
 		#########################
-		#                                            $4              $5
-		} elsif ($line =~ /^${ansi_color_regex}diff (-r|--git|--cc) (.+?)(\s|\e|$)/) {
+		} elsif ($line =~ /^${ansi_color_regex}diff (.*)/) {
+			my $diff_args = $4;
 
 			# Mercurial looks like: diff -r 82e55d328c8c hello.c
-			if ($4 eq "-r") {
+			if ($diff_args =~ /^-r [0-9a-f]+ /) {
 				$is_mercurial = 1;
 				$meta_color ||= get_config_color("meta");
+
 			# Git looks like: diff --git a/diff-so-fancy b/diff-so-fancy
+			} elsif ($diff_args =~ /^(?:--git|--cc) (.+?)(\s|\e|$)/) {
+			    $last_file_seen = $1;
+
+			# Otherwise, last two args are file names.  Assume they have no
+			# spaces, as "a b c" is ambiguous anyway.
 			} else {
-				$last_file_seen = $5;
+				$diff_args =~ s/\e.*$//;
+				$diff_args =~ /([^ ]+) [^ ]+$/;
+				$last_file_seen = $1;
 			}
 
 			$last_file_seen =~ s|^\w/||; # Remove a/ (and handle diff.mnemonicPrefix).

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -223,3 +223,8 @@ output=$( load_fixture "ls-function" | $diff_so_fancy )
 	assert_line --index 1 --partial "modified: doc/manual.xml.head"
 	assert_line --index 3 --partial "@ doc/manual.xml.head:8355 @"
 }
+
+@test "arbitrary diff args" {
+  output=$( load_fixture "unified-recursive" | $diff_so_fancy )
+  refute_output --partial 'diff -ur'
+}

--- a/test/fixtures/unified-recursive.diff
+++ b/test/fixtures/unified-recursive.diff
@@ -1,0 +1,25 @@
+Only in new: added.txt
+Only in old: deleted.txt
+diff -ur old/modified.txt new/modified.txt
+--- old/modified.txt	2018-03-22 11:45:03.000000000 -0700
++++ new/modified.txt	2018-03-22 11:45:11.000000000 -0700
+@@ -1 +1 @@
+-this is the old version
++this is the new version
+diff -ur old/modified2.txt new/modified2.txt
+--- old/modified2.txt	2018-03-22 13:23:01.000000000 -0700
++++ new/modified2.txt	2018-03-22 13:23:16.000000000 -0700
+@@ -1,6 +1,6 @@
+ context1
+ context2
+-old stuff 1
++new stuff 1
+ context3
+ context4
+ context5
+@@ -8,4 +8,4 @@
+ context7
+ context8
+ context9
+-old stuff 2
++new stuff 2


### PR DESCRIPTION
I found that the existing work on #220 didn't really work well for me with with the output of plain `diff(1)`, particularly recursive diffs.  These changes fix the matching on the filename line (which didn't allow for the `-u` flag), and add colorization to hunk markers and "Only in ..." lines.

