### PR TITLE
Add config for file header ruler width (rulerWidth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ By default the separator for the file header uses Unicode line drawing character
 git config --bool --global diff-so-fancy.useUnicodeRuler false
 ```
 
+### rulerWidth
+
+By default the separator for the file header spans the full width of the terminal. Use this setting to set the width of the file header manually.
+```
+git config --global diff-so-fancy.rulerWidth 47    # git log's commit header width
+```
+
 ## Contributing
 
 Pull requests are quite welcome, and should target the [`next` branch](https://github.com/so-fancy/diff-so-fancy/tree/next). We are also looking for any feedback or ideas on how to make diff-so-fancy even better.

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -22,6 +22,7 @@ my $change_hunk_indicators     = git_config_boolean("diff-so-fancy.changeHunkInd
 my $strip_leading_indicators   = git_config_boolean("diff-so-fancy.stripLeadingSymbols","true");
 my $mark_empty_lines           = git_config_boolean("diff-so-fancy.markEmptyLines","true");
 my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRuler","true");
+my $ruler_width                = git_config("diff-so-fancy.rulerWidth", undef);
 my $git_strip_prefix           = git_config_boolean("diff.noprefix","false");
 my $has_stdin                  = has_stdin();
 
@@ -557,7 +558,7 @@ sub trim {
 # Print a line of em-dash or line-drawing chars the full width of the screen
 sub horizontal_rule {
 	my $color = $_[0] || "";
-	my $width = `tput cols`;
+	my $width = $ruler_width || `tput cols`;
 
 	if (is_windows()) {
 		$width--;


### PR DESCRIPTION
I use `git log -p` frequently and I found the full-width file headers distracting when reading commits. I didn't want the separator between files within a commit to overshadow the separation of commits themselves. 

I think a shorter header width is better but naturally it should be an option!

Thanks for your work on this project.