### PR TITLE
Match escape sequences wide enough to hold bold, truecolor fg, and truecolor bg.

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -25,7 +25,7 @@ my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRul
 my $git_strip_prefix           = git_config_boolean("diff.noprefix","false");
 my $has_stdin                  = has_stdin();
 
-my $ansi_color_regex = qr/(\e\[([0-9]{1,3}(;[0-9]{1,3}){0,6})[mK])?/;
+my $ansi_color_regex = qr/(\e\[([0-9]{1,3}(;[0-9]{1,3}){0,10})[mK])?/;
 my $reset_color      = color("reset");
 my $bold             = color("bold");
 my $meta_color       = "";

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -24,6 +24,14 @@ output=$( load_fixture "ls-function" | $diff_so_fancy )
 	refute_line --index 22 --regexp "-    eval \"env CLICOLOR"
 }
 
+@test "+/- line symbols are stripped (truecolor)" {
+  output=$( load_fixture "truecolor" | $diff_so_fancy )
+  refute_output --partial "
+[1;38;2;220;50;47;48;2;0;43;54m-"
+  refute_output --partial "
+[1;38;2;133;153;0;48;2;0;43;54m+"
+}
+
 @test "empty lines added/removed are marked" {
 	run printf "%s" "$output"
 

--- a/test/fixtures/truecolor.diff
+++ b/test/fixtures/truecolor.diff
@@ -1,0 +1,14 @@
+[33mdiff --git package.json package.json[m
+[33mindex 97965ab..f3ce90a 100644[m
+[33m--- package.json[m
+[33m+++ package.json[m
+[1;35m@@ -13,8 +13,8 @@[m
+     "url": "git+https://github.com/so-fancy/diff-so-fancy.git"[m
+   },[m
+   "keywords": [[m
+[1;38;2;220;50;47;48;2;0;43;54m-    "git",[m
+     "diff",[m
+[1;38;2;133;153;0;48;2;0;43;54m+[m[1;38;2;133;153;0;48;2;0;43;54m    "git",[m
+     "fancy",[m
+     "good-lookin'",[m
+     "diff-highlight",[m


### PR DESCRIPTION
After a `git config --global color.diff.new '#859900 #002b36 bold'`, git will start
emitting escape sequences that look like `^[[1;38;2;133;153;0;48;2;0;43;54m`. Update
regex repetition to number of possible arguments in play (bold=1, fg=5, bg=5).

Fixes #299.