### PR TITLE
Fix #321: build fails on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ perl:
 matrix:
   include:
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.4
       language: generic
       perl: 5.24
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,16 @@ matrix:
   allow_failures:
     - perl: "blead"
 
+addons:
+  homebrew:
+    packages:
+      - perl
+      - shellcheck
+      - cpanminus
+
 before_install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      brew install shellcheck perl cpanminus;
       mkdir -p ~/perl5;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/report-bug.sh
+++ b/report-bug.sh
@@ -23,12 +23,12 @@ clipboard() {
       copy_cmd=clip
     fi
     # copy_cmd=clip
-  elif which pbcopy >/dev/null 2>&1; then
+  elif command -v pbcopy >/dev/null 2>&1; then
     copy_cmd="pbcopy"
-  elif which xclip >/dev/null 2>&1; then
+  elif command -v xclip >/dev/null 2>&1; then
     # copy_cmd="xclip -i -selection clipboard"
     copy_cmd="xclip"
-  elif which xsel  >/dev/null 2>&1 ; then
+  elif command -v xsel >/dev/null 2>&1 ; then
     local copy_cmd="xsel -b"
   fi
   if [ -n "$copy_cmd" ] ;then


### PR DESCRIPTION
A simple upgrade of the MacOS/XCode version is sufficient to get the builds working on MacOS too. I hope this is an acceptable solution. There is still an error reported by shellcheck ([SC2230](https://github.com/koalaman/shellcheck/wiki/SC2230)) but I guess it is not related to MacOS itself but rather the shellcheck version or configuration.

My second commit is not necessary to fix #321 , it just follows a best practice suggested by Travis.