### PR TITLE
Fix MacOS Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,15 @@ addons:
       - perl
       - shellcheck
       - cpanminus
+    update: true
 
 before_install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git
-  - eval $(curl https://travis-perl.github.io/init) --perl;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       mkdir -p ~/perl5;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      eval $(curl https://travis-perl.github.io/init) --perl;
       sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-backports restricted main universe";
       sudo apt-get -y update;
       sudo apt-get -y install shellcheck;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,11 @@ addons:
 
 before_install:
   - git clone --depth 1 https://github.com/sstephenson/bats.git
+  - eval $(curl https://travis-perl.github.io/init) --perl;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       mkdir -p ~/perl5;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      eval $(curl https://travis-perl.github.io/init) --perl;
-
       sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-backports restricted main universe";
       sudo apt-get -y update;
       sudo apt-get -y install shellcheck;


### PR DESCRIPTION
Fix MacOS Travis Tests by requiring Homebrew to manually update before installing its dependencies. 

This fix still leaves me wondering how this option is one at all, when there is no way to install dependencies with an outdated brew database, meaning without this option.