### PR TITLE
docs: add 'color.diff.func' color to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ git config --global color.diff-highlight.newHighlight "green bold 22"
 
 git config --global color.diff.meta       "11"
 git config --global color.diff.frag       "magenta bold"
+git config --global color.diff.func       "146 bold"
 git config --global color.diff.commit     "yellow bold"
 git config --global color.diff.old        "red bold"
 git config --global color.diff.new        "green bold"


### PR DESCRIPTION
Two small improvements to the documentation:

- `git --no-pager` can be abbreviated `git -P` in Git 2.18 or later,
so mention this in pro-tips.md

- The color for hunk headers (`color.diff.func`) is hardcoded in the
script, and is not mentioned in the "Improved colors for the
highlighted bits" section of the README. Add it there so that function
headers with or without diff-so-fancy use the same color configuration.

I based this branch on master since it appears next is behind master. I will rebase on next if required.