### PR TITLE
Don't include ansi color codes in file1 and file2

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -318,10 +318,10 @@ sub do_dsf_stuff {
 			}
 
 			my $next    = shift(@$input);
-			my ($file1) = $next =~ /rename from (.+)/;
+			my ($file1) = $next =~ /rename from (.+?)(\e|\t|$)/;
 
 			$next       = shift(@$input);
-			my ($file2) = $next =~ /rename to (.+)/;
+			my ($file2) = $next =~ /rename to (.+?)(\e|\t|$)/;
 
 			if ($file1 && $file2) {
 				# We may not have extracted this yet, so we pull from the config if not
@@ -625,14 +625,10 @@ sub file_change_string {
 	# If the files aren't the same it's a rename
 	} elsif ($file_1 ne $file_2) {
 		my ($old, $new) = DiffHighlight::highlight_pair($file_1,$file_2,{only_diff => 1});
+		# highlight_pair already includes reset_color, but adds newline characters that need to be trimmed off
 		$old = trim($old);
 		$new = trim($new);
-
-		# highlight_pair resets the colors, but we want it to be the meta color
-		$old =~ s/(\e0?\[m)/$1$meta_color/g;
-		$new =~ s/(\e0?\[m)/$1$meta_color/g;
-
-		return "renamed: $old to $new";
+		return "renamed: $old$meta_color to $new"
 	# Something we haven't thought of yet
 	} else {
 		return "$file_1 -> $file_2";


### PR DESCRIPTION
when processing renamed files. Use the same `(.+?)(\e|\t|$)` regexp used in other similar parts of the code. The motivation behind this change is to be able to process the file1 and file2 strings (e.g. get their length) without the interference of the extra ansi color codes. Also, the resulting d-s-f output is smaller with this change (34 bytes less for each "renamed: X to Y" line).

![Screen Shot 2020-11-03 at 08 36 35](https://user-images.githubusercontent.com/4120606/98320059-13185900-1fb0-11eb-8875-055e14658d3c.png)
