### PR TITLE
Trim down npm tarball size

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,6 @@
   "name": "diff-so-fancy",
   "version": "1.3.0",
   "description": "Good-lookin' diffs with diff-highlight and more",
-  "bin": {
-    "diff-so-fancy": "diff-so-fancy"
-  },
-  "scripts": {
-    "test": "bats test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/so-fancy/diff-so-fancy.git"
-  },
   "keywords": [
     "git",
     "diff",
@@ -22,10 +12,20 @@
     "readable",
     "highlight"
   ],
-  "author": "Paul Irish",
-  "license": "MIT",
+  "homepage": "https://github.com/so-fancy/diff-so-fancy#readme",
   "bugs": {
     "url": "https://github.com/so-fancy/diff-so-fancy/issues"
   },
-  "homepage": "https://github.com/so-fancy/diff-so-fancy#readme"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/so-fancy/diff-so-fancy.git"
+  },
+  "license": "MIT",
+  "author": "Paul Irish",
+  "bin": {
+    "diff-so-fancy": "diff-so-fancy"
+  },
+  "scripts": {
+    "test": "bats test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
   "bin": {
     "diff-so-fancy": "diff-so-fancy"
   },
+  "files": [
+    "diff-so-fancy",
+    "lib",
+    "third_party"
+  ],
   "scripts": {
     "test": "bats test"
   }


### PR DESCRIPTION
Trim down tarball size by leveraging the `files` field. :tada:

### Before

```
npm notice === Tarball Details === 
npm notice name:          diff-so-fancy                           
npm notice version:       1.3.0                                   
npm notice filename:      diff-so-fancy-1.3.0.tgz                 
npm notice package size:  62.8 kB                                 
npm notice unpacked size: 250.7 kB                                
npm notice shasum:        1559a03fc66cc79c5c8a53cdb2837b732e679d22
npm notice integrity:     sha512-IrMM3X1Avqwa1[...]uV3BuXab2AWbA==
npm notice total files:   82                                      
npm notice 
diff-so-fancy-1.3.0.tgz
```

---

### After

```
npm notice === Tarball Details === 
npm notice name:          diff-so-fancy                           
npm notice version:       1.3.0                                   
npm notice filename:      diff-so-fancy-1.3.0.tgz                 
npm notice package size:  27.0 kB                                 
npm notice unpacked size: 85.1 kB                                 
npm notice shasum:        db2c37ae6759dec883a7fc1bf6e1a869e29ba0f4
npm notice integrity:     sha512-w2IZsbrGpe/6a[...]cz760H6fJk56Q==
npm notice total files:   10                                      
npm notice 
diff-so-fancy-1.3.0.tgz
```