### PR TITLE
Update pro-tips.md to use a simpler alias and corresponding pager

### DIFF
--- a/pro-tips.md
+++ b/pro-tips.md
@@ -2,10 +2,12 @@
 
 #### One-off fanciness or a specific diff-so-fancy alias
 
-You can do also do a one-off or a specific `diff-so-fancy` alias:
+You can do also do a one-off:
 ```shell
 git diff --color | diff-so-fancy
-
+```
+or configure an alias to use `diff-so-fancy`:
+```shell
 git config --global alias.dsf '!f() { [ -z "$GIT_PREFIX" ] || cd "$GIT_PREFIX" '\
 '&& git diff --color "$@" | diff-so-fancy  | less --tabs=4 -RFXS; }; f'
 ```

--- a/pro-tips.md
+++ b/pro-tips.md
@@ -6,10 +6,10 @@ You can do also do a one-off:
 ```shell
 git diff --color | diff-so-fancy
 ```
-or configure an alias to use `diff-so-fancy`:
+or configure an alias and a corresponding pager to use `diff-so-fancy`:
 ```shell
-git config --global alias.dsf '!f() { [ -z "$GIT_PREFIX" ] || cd "$GIT_PREFIX" '\
-'&& git diff --color "$@" | diff-so-fancy  | less --tabs=4 -RFXS; }; f'
+git config --global alias.dsf "diff --color"
+git config --global pager.dsf "diff-so-fancy | less --tabs=4 -RFXS"
 ```
 
 #### Opting-out


### PR DESCRIPTION
This setup makes use of an additional `pager` config for the `dsf` alias to avoid having to spawn a new shell command, forward the arguments, and deal with internal details like `$GIT_PREFIX`.