### PR TITLE
Include new files in patch mode

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -288,6 +288,9 @@ sub do_dsf_stuff {
 		} elsif ($remove_file_add_header && $line =~ /^${ansi_color_regex}.*new file mode/) {
 			# Don't print the line (i.e. remove it from the output);
 			$last_file_mode = "add";
+			if ($patch_mode) {
+				print "\n";
+			}
 		######################################
 		# Remove any delete file permissions #
 		######################################


### PR DESCRIPTION
More work on #35

It turns out that new files can be part of `git add --patch` by using
`git add --intent-to-add` on them first.