### PR TITLE
Link installation docs to known packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Vanilla `git diff` vs `git` and `diff-so-fancy`
 
 Installation is as simple as cloning this repo and then putting the `diff-so-fancy` script in to your `$PATH`. The `lib/` directory will need to be kept relative to the core script.
 
-`diff-so-fancy` is also available from NPM, Nix, brew, and as a package on Arch and Debian Linux.
+`diff-so-fancy` is also available from the [NPM registry](https://www.npmjs.com/package/diff-so-fancy), [brew](https://formulae.brew.sh/formula/diff-so-fancy), and as a package on [Nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix), in the [Arch community repo](https://archlinux.org/packages/community/any/diff-so-fancy/), and [ppa:aos for Debian/Ubuntu Linux](https://github.com/aos/dsf-debian).
+
+Issues relating to packaging ('installation does not work', 'version is out of date', etc.) should be directed to those packages' own repositories/issue trackers where applicable.
 
 **Note:** Windows users may need to install [MinGW](https://sourceforge.net/projects/mingw/files/) or the [Windows subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 


### PR DESCRIPTION
Closes #380.

Is that wording appropriate @aos?  (I'm not a Debian user) I take it it is only available from your repo/'ppa' that has to be manually added, it's not just a case of `apt install` on a fresh system?

(Targetting master rather than next since it's a readme-only change relevant for existing versions, and that's the default displayed branch on GitHub.)