### PR TITLE
Only call sub git_config_raw once

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -434,29 +434,18 @@ sub boolean {
 	}
 }
 
-# Memoize getting the git config
+# Get the git config
 sub git_config_raw {
-	state $static_config;
-
-	if ($static_config) {
-		# If we already have the config return that
-		return $static_config;
-	}
-
 	my $cmd = "git config --list";
 	my @out = `$cmd`;
-
-	$static_config = \@out;
 
 	return \@out;
 }
 
-# Fetch a textual item from the git config
+# Memoize fetching a textual item from the git config
 sub git_config {
 	my $search_key    = lc($_[0] || "");
 	my $default_value = lc($_[1] || "");
-
-	my $out = git_config_raw();
 
 	# If we're in a unit test, use the default (don't read the users config)
 	if (in_unit_test()) {
@@ -471,6 +460,8 @@ sub git_config {
 	if ($args->{debug}) {
 		print "Parsing git config\n";
 	}
+
+	my $out = git_config_raw();
 
 	foreach my $line (@$out) {
 		if ($line =~ /=/) {


### PR DESCRIPTION
and no need to memoize its output, since the parsed output is already memoized in sub git_config.

Cool to see getting the git config was already highly optimized. This is all I could see that still could be simplified. 

There's no significant time improvements with this change, but we're just making less calls to sub git_config_raw (1 instead of as many calls to sub git_config), and also not memoizing that extra raw git config output.

### Before
```
time elapsed (wall):   0.1345
time running program:  0.1278  (95.04%)
time profiling (est.): 0.0067  (4.96%)
number of calls:       6576

%Time    Sec.     #calls   sec/call  F  name
46.91    0.0600       37   0.001620     main::do_dsf_stuff
10.01    0.0128       15   0.000853     main::git_config_raw
 7.55    0.0096     1049   0.000009     DiffHighlight::handle_line
 7.20    0.0092        0   0.009205  *  <other>
...

❯ perl third_party/cli_bench/cli_bench.pl "cat test/fixtures/*.diff | ./diff-so-fancy"
...................................................

67 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (17.5%)
68 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (32.5%)
69 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (30.0%)
70 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (20.0%)

Ran 'cat test/fixtures/*.diff | ./diff-so-fancy' 50 times with average completion time of 68 ms
```

### After
```
time elapsed (wall):   0.1085
time running program:  0.1022  (94.18%)
time profiling (est.): 0.0063  (5.82%)
number of calls:       6562

%Time    Sec.     #calls   sec/call  F  name
31.95    0.0327       37   0.000882     main::do_dsf_stuff
11.91    0.0122        1   0.012173     main::git_config_raw
 8.90    0.0091     1049   0.000009     DiffHighlight::handle_line
 8.43    0.0086        0   0.008616  *  <other>
...

❯ perl third_party/cli_bench/cli_bench.pl "cat test/fixtures/*.diff | ./diff-so-fancy"
...................................................

67 ms: %%%%%%%%%%%%%% (7.5%)
68 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (45.0%)
69 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% (32.5%)
70 ms: %%%%%%%%%%%%%%%%%%%%%%%%%%%% (15.0%)

Ran 'cat test/fixtures/*.diff | ./diff-so-fancy' 50 times with average completion time of 68 ms
```

