### PR TITLE
Fix fg/bg extraction with l.t. 2 colors

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -918,13 +918,14 @@ sub git_ansi_color {
 
 	if (grep { /bold/ } @parts) {
 		push(@ansi_part, "1");
-		@parts = grep { !/bold/ } @parts; # Remove from array
 	}
 
 	if (grep { /reverse/ } @parts) {
 		push(@ansi_part, "7");
-		@parts = grep { !/reverse/ } @parts; # Remove from array
 	}
+
+	# Remove parts that aren't colors
+	@parts = grep { exists $colors->{$_} || is_numeric($_) } @parts;
 
 	my $fg  = $parts[0] // "";
 	my $bg  = $parts[1] // "";

--- a/test/git_ansi_color.pl
+++ b/test/git_ansi_color.pl
@@ -121,13 +121,14 @@ sub git_ansi_color {
 
 	if (grep { /bold/ } @parts) {
 		push(@ansi_part, "1");
-		@parts = grep { !/bold/ } @parts; # Remove from array
 	}
 
 	if (grep { /reverse/ } @parts) {
 		push(@ansi_part, "7");
-		@parts = grep { !/reverse/ } @parts; # Remove from array
 	}
+
+	# Remove parts that aren't colors
+	@parts = grep { exists $colors->{$_} || is_numeric($_) } @parts;
 
 	my $fg  = $parts[0] // "";
 	my $bg  = $parts[1] // "";


### PR DESCRIPTION
Hi, this PR fixes a bug I found because I have a configuration like this:

```
[color "diff"]
        old = red strike
```

In short, it wasn't considered the case where 1) less than 2 colors are specified, with 2) at least one modifier different from `bold` or `reverse`.

The bug can be reproduced by setting `git config color.diff.old "red strike"` in `test/test_helper/util.bash` and running the test suite, but I'm not familiar enough with bats to add a regression test, as it seems to affect the configuration before the tests run.

I hope it is useful :)