### PR TITLE
test: use isolated, temporary `GIT_CONFIG`

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -490,24 +490,10 @@ sub git_config_boolean {
 	my $search_key    = lc($_[0] || "");
 	my $default_value = lc($_[1] || 0); # Default to false
 
-	# If we're in a unit test, use the default (don't read the users config)
-	if (in_unit_test()) {
-		return boolean($default_value);
-	}
-
 	my $result = git_config($search_key,$default_value);
 	my $ret    = boolean($result);
 
 	return $ret;
-}
-
-# Check if we're inside of BATS
-sub in_unit_test {
-	if ($ENV{BATS_CWD}) {
-		return 1;
-	} else {
-		return 0;
-	}
 }
 
 sub get_less_charset {

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -9,10 +9,15 @@ __load_imports__() {
 
 setup_file() {
 	__load_imports__
+	setup_default_dsf_git_config
 }
 
 setup() {
 	__load_imports__
+}
+
+teardown_file() {
+	teardown_default_dsf_git_config
 }
 
 # https://github.com/paulirish/dotfiles/commit/6743b907ff586c28cd36e08d1e1c634e2968893e#commitcomment-13459061

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -10,14 +10,19 @@ __load_imports__() {
 setup_file() {
 	__load_imports__
 	set_env
+	setup_default_dsf_git_config
 	# bats fails to handle our multiline result, so we save to $output ourselves
-	__dfs_cached_output="$( load_fixture "ls-function" | $diff_so_fancy )"
-	export __dfs_cached_output
+	__dsf_cached_output="$( load_fixture "ls-function" | $diff_so_fancy )"
+	export __dsf_cached_output
 }
 
 setup() {
 	__load_imports__
-	output="${__dfs_cached_output}"
+	output="${__dsf_cached_output}"
+}
+
+teardown_file() {
+	teardown_default_dsf_git_config
 }
 
 @test "diff-so-fancy runs and exits without error" {

--- a/test/test_helper/util.bash
+++ b/test/test_helper/util.bash
@@ -10,17 +10,36 @@ set_env() {
   export LC_CTYPE="en_US.UTF-8"
 }
 
+dsf_test_git_config() {
+  printf '%s/gitconfig' "${BATS_TMPDIR}"
+}
 
 # applying colors so ANSI color values will match
 # FIXME: not everyone will have these set, so we need to test for that.
-git config color.diff.meta "227"
-git config color.diff.frag "magenta bold"
-git config color.diff.commit "227 bold"
-git config color.diff.old "red bold"
-git config color.diff.new "green bold"
-git config color.diff.whitespace "red reverse"
+setup_default_dsf_git_config() {
+  GIT_CONFIG="$(dsf_test_git_config)" || return $?
+  cat > "${GIT_CONFIG}" <<EOF || return $?
+[color "diff"]
+	meta = 227
+	frag = magenta bold
+	commit = 227 bold
+	old = red bold
+	new = green bold
+	whitespace = red reverse
 
-git config color.diff-highlight.oldNormal "red bold"
-git config color.diff-highlight.oldHighlight "red bold 52"
-git config color.diff-highlight.newNormal "green bold"
-git config color.diff-highlight.newHighlight "green bold 22"
+[color "diff-highlight"]
+	oldNormal = red bold
+	oldHighlight = red bold 52
+	newNormal = green bold
+	newHighlight = green bold 22
+EOF
+  export GIT_CONFIG
+  export GIT_CONFIG_NOSYSTEM=1
+}
+
+teardown_default_dsf_git_config() {
+  local test_config
+  test_config="$(dsf_test_git_config)" || return $?
+  [ ! -f "${test_config}" ] || rm -f "${test_config}"
+  GIT_CONFIG=/dev/null
+}


### PR DESCRIPTION
I noticed that the unit tests were changing the configuration in `.git/config`. They also read user configuration as fallback values, which made things verifying correct behaviour confusing—especially when some user configuration matches the defaults!

(Although there was a specific guard checking against `in_unit_test`, that was only for boolean config values, not configuration in general).

This generates a gitconfig in `$BATS_TMPDIR` and exports both `GIT_CONFIG=…` and `GIT_CONFIG_NOSYSTEM=1`, which `git` will respect for isolating that configuration.

That setup and teardown is done in `setup_file` (once per suite, rather than once per test). Some other test setup has been moved into those bat callbacks as well.