### PR TITLE
fix: over-permissive regex for added/deleted file meta header

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -303,7 +303,7 @@ sub do_dsf_stuff {
 		###################################
 		# Remove any new file permissions #
 		###################################
-		} elsif ($remove_file_add_header && $line =~ /^${ansi_color_regex}.*new file mode/) {
+		} elsif ($remove_file_add_header && $line =~ /^${ansi_color_regex}new file mode [0-7]{6}/) {
 			# Don't print the line (i.e. remove it from the output);
 			$last_file_mode = "add";
 			if ($patch_mode) {
@@ -312,7 +312,7 @@ sub do_dsf_stuff {
 		######################################
 		# Remove any delete file permissions #
 		######################################
-		} elsif ($remove_file_delete_header && $line =~ /^${ansi_color_regex}deleted file mode/) {
+		} elsif ($remove_file_delete_header && $line =~ /^${ansi_color_regex}deleted file mode [0-7]{6}/) {
 			# Don't print the line (i.e. remove it from the output);
 			$last_file_mode = "delete";
 			if ($patch_mode) {


### PR DESCRIPTION
Noticed this because the line itself was filtered out of diffs in this codebase.

The previous pattern uselessly included `.*`, unlike all the other patterns, and so would erroneously match on actual diff content lines.

This also tightens the pattern since the file mode will always be six octal (0-7) chars; and in the git codebase the format string is: `"%s%snew file mode %06o%s\n"`.