### PR TITLE
fix: `starts_with_ansi` always returned 1 and had inverted logic

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -993,7 +993,8 @@ sub is_numeric {
 sub starts_with_ansi {
 	my $str = shift();
 
-	if ($str =~ /^$ansi_color_regex/) {
+	# NOTE: This is not `ansi_color_regex`, which includes "no ANSI sequences".
+	if ($str =~ /^$ansi_regex/) {
 		return 1;
 	} else {
 		return 0;


### PR DESCRIPTION
`$ansi_color_regex` is defined as `(…)?` and so `/^$ansi_color_regex/` will *always* match. This PR factors the ANSI-sequence part of the regex itself and checks (non-optionally) against that.

Additionally, the logic checking `starts_with_ansi` was inverted, likely to compensate for the above error, but as a side effect forcing `diff-so-fancy` always to color lines unnecessarily.