### PR TITLE
Re-enable less termcap initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Issues relating to packaging ('installation does not work', 'version is out of d
 Configure git to use `diff-so-fancy` for all diff output:
 
 ```shell
-git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
+git config --global core.pager "diff-so-fancy | less --tabs=4 -RF"
 git config --global interactive.diffFilter "diff-so-fancy --patch"
 ```
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -726,7 +726,7 @@ diff-so-fancy --set-defaults             # Configure git-diff to use diff-so-fan
 diff-so-fancy --patch                    # Use diff-so-fancy in patch mode (interoperable with `git add --patch`)
 
 # Configure git to use d-s-f for *all* diff operations
-git config --global core.pager \"diff-so-fancy | less --tabs=4 -RFX\"
+git config --global core.pager \"diff-so-fancy | less --tabs=4 -RF\"
 
 # Configure git to use d-s-f for `git add --patch`
 git config --global interactive.diffFilter \"diff-so-fancy --patch\"\n";
@@ -803,7 +803,7 @@ sub check_first_run {
 
 sub set_defaults {
 	my $color_config = get_default_colors();
-	my $git_config   = 'git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"';
+	my $git_config   = 'git config --global core.pager "diff-so-fancy | less --tabs=4 -RF"';
 	my $first_cmd    = 'git config --global diff-so-fancy.first-run false';
 
 	my @cmds = split(/\n/,$color_config);

--- a/pro-tips.md
+++ b/pro-tips.md
@@ -9,7 +9,7 @@ git diff --color | diff-so-fancy
 or configure an alias and a corresponding pager to use `diff-so-fancy`:
 ```shell
 git config --global alias.dsf "diff --color"
-git config --global pager.dsf "diff-so-fancy | less --tabs=4 -RFXS"
+git config --global pager.dsf "diff-so-fancy | less --tabs=4 -RFS"
 ```
 
 #### Opting-out
@@ -36,7 +36,7 @@ You can pre-seed your `less` pager with a search pattern, so you can move
 between files with `n`/`N` keys:
 ```ini
 [pager]
-    diff = diff-so-fancy | less --tabs=4 -RFXS --pattern '^(Date|added|deleted|modified): '
+    diff = diff-so-fancy | less --tabs=4 -RFS --pattern '^(Date|added|deleted|modified): '
 ```
 
 #### Zsh plugin providing diff-so-fancy

--- a/third_party/build_fatpack/diff-so-fancy
+++ b/third_party/build_fatpack/diff-so-fancy
@@ -1061,7 +1061,7 @@ diff-so-fancy --set-defaults             # Configure git-diff to use diff-so-fan
 diff-so-fancy --patch                    # Use diff-so-fancy in patch mode (interoperable with `git add --patch`)
 
 # Configure git to use d-s-f for *all* diff operations
-git config --global core.pager \"diff-so-fancy | less --tabs=4 -RFX\"
+git config --global core.pager \"diff-so-fancy | less --tabs=4 -RF\"
 
 # Configure git to use d-s-f for `git add --patch`
 git config --global interactive.diffFilter \"diff-so-fancy --patch\"\n";
@@ -1138,7 +1138,7 @@ sub check_first_run {
 
 sub set_defaults {
 	my $color_config = get_default_colors();
-	my $git_config   = 'git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"';
+	my $git_config   = 'git config --global core.pager "diff-so-fancy | less --tabs=4 -RF"';
 	my $first_cmd    = 'git config --global diff-so-fancy.first-run false';
 
 	my @cmds = split(/\n/,$color_config);


### PR DESCRIPTION
This commit removes usage of the the -X option from diff-so-fancy, which prevented less termcap initialization. From the manpage:

> ```
> -X or --no-init
>     Disables sending the termcap initialization and deinitialization
>     strings to the terminal. This is sometimes desirable if the
>     deinitialization string does something unnecessary, like clearing
>     the screen.
> ```

The default behavior of `less` is to signal termcap initialization. This behavior provides a number of nice features, including that the output disappears when `less` is closed, and that mouse scrolling of the less viewport works automatically on terminals such as gnome-terminal.

I believe that this is a sensible default, and it ensures that diff-so-fancy works out of the box with fetaures users have come to expect of `less`.
