### PR TITLE
Add a reset to remove bold when not asked

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -300,7 +300,7 @@ sub do_dsf_stuff {
 				print $frag_color;
 			}
 
-			print "@ $last_file_seen:$start_line \@${bold}${last_function_color}${remain}${reset_color}\n";
+			print "@ $last_file_seen:$start_line \@${reset_color}${last_function_color}${remain}${reset_color}\n";
 		###################################
 		# Remove any new file permissions #
 		###################################


### PR DESCRIPTION
Some part are bold even if not configure to be

`func` on this example:

![image](https://user-images.githubusercontent.com/245365/189704624-54d35764-657a-4969-b901-a24194676577.png)

Reseting ascii at the begining fixes it