### PR TITLE
bump required perl version

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -4,7 +4,7 @@ my $VERSION = "1.4.2";
 
 #################################################################################
 
-use v5.010;                                                 # Require Perl 5.10 for 'state' variables
+use v5.014;                                                 # Require Perl 5.14 for 'state' variables and /u in regexes
 use warnings FATAL => 'all';
 use strict;
 


### PR DESCRIPTION
 - /u is added in perl 5.14 - [link to perl5140delta](https://perldoc.perl.org/5.14.4/perl5140delta#/d,-/l,-/u,-and-/a-modifiers)

With perl 5.12:
```
morbeo@qa:~ perl -v

This is perl 5, version 12, subversion 5 (v5.12.5) built for x86_64-linux
(with 1 registered patch, see perl -V for more detail)

Copyright 1987-2012, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.

morbeo@qa:~ diff-so-fancy
Bareword found where operator expected at /home/morbeo/bin/diff-so-fancy line 624, near "s/^\s*//u"
```
With perl 5.14
```
morbeo@qa:~ perlbrew switch perl-5.14.4
morbeo@qa:~ diff-so-fancy
Diff-so-fancy: https://github.com/so-fancy/diff-so-fancy
Version      : 1.4.2

Usage:

git diff --color | diff-so-fancy         # Use d-s-f on one diff
cat diff.txt | diff-so-fancy             # Use d-s-f on a diff/patch file
diff -u one.txt two.txt | diff-so-fancy  # Use d-s-f on unified diff output

diff-so-fancy --colors                   # View the commands to set the recommended colors
diff-so-fancy --set-defaults             # Configure git-diff to use diff-so-fancy and suggested colors
diff-so-fancy --patch                    # Use diff-so-fancy in patch mode (interoperable with `git add --patch`)

# Configure git to use d-s-f for *all* diff operations
git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"

# Configure git to use d-s-f for `git add --patch`
git config --global interactive.diffFilter "diff-so-fancy --patch"
```