### PR TITLE
fix and maint: match most git supported color settings

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -909,19 +909,19 @@ sub git_ansi_color {
 
 	my @ansi_part = ();
 
-	if (grep { /bold/ } @parts) {
+	if (grep { /^bold$/ } @parts) {
 		push(@ansi_part, "1");
 	}
 
-	if (grep { /dim/ } @parts) {
+	if (grep { /^dim$/ } @parts) {
 		push(@ansi_part, "2");
 	}
 
-	if (grep { /ul/ } @parts) {
+	if (grep { /^ul$/ } @parts) {
 		push(@ansi_part, "4");
 	}
 
-	if (grep { /reverse/ } @parts) {
+	if (grep { /^reverse$/ } @parts) {
 		push(@ansi_part, "7");
 	}
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -928,7 +928,7 @@ sub git_ansi_color {
 	}
 
 	# Remove parts that aren't colors
-	@parts = grep { exists $colors->{$_} || is_numeric($_) } @parts;
+	@parts = grep { exists $colors->{$_} || is_numeric($_) || /^\#/ } @parts;
 
 	my $fg  = $parts[0] // "";
 	my $bg  = $parts[1] // "";
@@ -958,6 +958,10 @@ sub set_ansi_color {
 		} else {
 			push(@$ansi_part, "$base8_code;5;$color");
 		}
+	# It's a full rgb code
+	} elsif ($color =~ /^#/) {
+		my ($rgbr, $rgbg, $rgbb) = $color =~ /.(..)(..)(..)/;
+		push(@$ansi_part, "$base8_code;2;" . hex($rgbr) . ";" . hex($rgbg) . ";" . hex($rgbb));
 	# It's a simple 16 color OG ansi
 	} elsif ($color ne "normal") {
 		my $color_num = $colors->{$color} + $base_code;

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -900,6 +900,8 @@ sub git_ansi_color {
 		'magenta' => 5,
 		'cyan'    => 6,
 		'white'   => 7,
+		'default' => 9, # pseudo color (39/49 = set default)
+		'normal'  => -1, # placeholder color to be ignored
 	};
 
 	# Bright colors are just offsets from the "regular" color
@@ -957,7 +959,7 @@ sub set_ansi_color {
 			push(@$ansi_part, "$base8_code;5;$color");
 		}
 	# It's a simple 16 color OG ansi
-	} else {
+	} elsif ($color ne "normal") {
 		my $color_num = $colors->{$color} + $base_code;
 		push(@$ansi_part, $color_num);
 	}

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -931,39 +931,8 @@ sub git_ansi_color {
 	my $fg  = $parts[0] // "";
 	my $bg  = $parts[1] // "";
 
-	#############################################
-
-	# It's an numeric value, so it's an 8 bit color
-	if (is_numeric($fg)) {
-		if ($fg < 8) {
-			push(@ansi_part, $fg + 30);
-		} elsif ($fg < 16) {
-			push(@ansi_part, $fg + 82);
-		} else {
-			push(@ansi_part, "38;5;$fg");
-		}
-	# It's a simple 16 color OG ansi
-	} elsif ($fg) {
-		my $color_num = ($colors->{$fg} // 0) + 30;
-		push(@ansi_part, $color_num);
-	}
-
-	#############################################
-
-	# It's an numeric value, so it's an 8 bit color
-	if (is_numeric($bg)) {
-		if ($bg < 8) {
-			push(@ansi_part, $bg + 40);
-		} elsif ($bg < 16) {
-			push(@ansi_part, $bg + 92);
-		} else {
-			push(@ansi_part, "48;5;$bg");
-		}
-	# It's a simple 16 color OG ansi
-	} elsif ($bg) {
-		my $color_num = ($colors->{$bg} // 0) + 40;
-		push(@ansi_part, $color_num);
-	}
+	set_ansi_color( $fg, 0, \@ansi_part, $colors ) if $fg;
+	set_ansi_color( $bg, 10, \@ansi_part, $colors ) if $bg;
 
 	#############################################
 
@@ -971,6 +940,27 @@ sub git_ansi_color {
 	my $ret      = "\e[" . $ansi_str . "m";
 
 	return $ret;
+}
+
+sub set_ansi_color {
+	my ($color, $increment, $ansi_part, $colors) = @_;
+	my $base_code = 30 + $increment;
+	my $base8_code = 38 + $increment;
+	my $ext_code = 82 + $increment;
+
+	if (is_numeric($color)) {
+		if ($color < 8) {
+			push(@$ansi_part, $color + $base_code);
+		} elsif ($color < 16) {
+			push(@$ansi_part, $color + $ext_code);
+		} else {
+			push(@$ansi_part, "$base8_code;5;$color");
+		}
+	# It's a simple 16 color OG ansi
+	} else {
+		my $color_num = $colors->{$color} + $base_code;
+		push(@$ansi_part, $color_num);
+	}
 }
 
 sub is_numeric {

--- a/test/git-config.bats
+++ b/test/git-config.bats
@@ -24,6 +24,7 @@ declare -Ag ansi_colors=(
     [magenta]='5'
     [cyan]='6'
     [white]='7'
+    [default]='9'
 )
 
 # get a foreground or background color code
@@ -109,4 +110,21 @@ teardown_file() {
     assert_line --index 3 --partial  "${escape}[${fg_blue};${bg_white}m@"
     assert_line --index 6 --partial  "${escape}[${fg_red};${bg_yellow}m--"
     assert_line --index 7 --partial  "${escape}[${fg_brightgreen}m--"
+}
+
+@test "Test normal and default git colors" {
+    config="
+	frag = normal default
+	old = default
+    "
+    setup_dsf_git_config "$config"
+
+	output=$( load_fixture "leading-dashes" | $diff_so_fancy )
+	run printf "%s" "$output"
+
+    fg_default=$(fg_color default)
+    bg_default=$(bg_color default)
+
+    assert_line --index 3 --partial  "${escape}[${bg_default}m@"
+    assert_line --index 6 --partial  "${escape}[${fg_default}m--"
 }

--- a/test/git-config.bats
+++ b/test/git-config.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+# Used by both `setup_file` and `setup`, which are special bats callbacks.
+__load_imports__() {
+	load 'test_helper/bats-support/load'
+	load 'test_helper/bats-assert/load'
+	load 'test_helper/util'
+}
+
+# ansi related values
+escape=$'\e'
+ansi_bold=1
+ansi_dim=2
+ansi_ul=4
+ansi_reverse=7
+
+# hash of colors
+declare -Ag ansi_colors=(
+    [black]='0'
+    [red]='1'
+    [green]='2'
+    [yellow]='3'
+    [blue]='4'
+    [magenta]='5'
+    [cyan]='6'
+    [white]='7'
+)
+
+# get a foreground or background color code
+ansi_color() {
+    color=$1
+    incr=$2
+    base_code=$((30+$incr))
+
+    # handle bright prefix
+    if [[ "${1}" =~ (bright)(.*) ]]
+    then
+        color=${BASH_REMATCH[2]}
+        base_code=$((90+$incr))
+    fi
+    code=$(($base_code+${ansi_colors[$color]}))
+    echo "$code"
+}
+
+# get a foreground color code
+fg_color() {
+    ansi_color $1 0
+}
+
+# get a background color code
+bg_color() {
+    ansi_color $1 10
+}
+
+# build config using passed in values
+setup_dsf_git_config() {
+  GIT_CONFIG="$(dsf_test_git_config)" || return $?
+  cat > "${GIT_CONFIG}" <<EOF || return $?
+[color "diff"]
+$1
+
+EOF
+  export GIT_CONFIG
+  export GIT_CONFIG_NOSYSTEM=1
+}
+
+setup_file() {
+	__load_imports__
+	# setup_default_dsf_git_config
+}
+
+setup() {
+	__load_imports__
+}
+
+teardown_file() {
+	teardown_default_dsf_git_config
+}
+
+# General description of how colors are applied
+# meta = header
+# frag = @ filenames
+# func = function name after frag
+# old  = - lines
+# new  = + lines
+
+@test "Test color attributes are removed" {
+    config="
+	meta = bold ul blink italic strike green no-reverse
+	frag = nobold nodim noul noblink noreverse noitalic nostrike blue white
+	func = dim reverse white purple
+	old = no-bold no-dim no-ul no-blink no-reverse no-italic no-strike red yellow
+	new = brightgreen
+	whitespace = red reverse
+    "
+    setup_dsf_git_config "$config"
+
+	output=$( load_fixture "leading-dashes" | $diff_so_fancy )
+	run printf "%s" "$output"
+
+    fg_green=$(fg_color green)
+    fg_blue=$(fg_color blue)
+    fg_red=$(fg_color red)
+    fg_brightgreen=$(fg_color brightgreen)
+    bg_white=$(bg_color white)
+    bg_yellow=$(bg_color yellow)
+
+    assert_line --index 0 --partial  "${escape}[${ansi_bold};${ansi_ul};${fg_green}m"
+    assert_line --index 3 --partial  "${escape}[${fg_blue};${bg_white}m@"
+    assert_line --index 6 --partial  "${escape}[${fg_red};${bg_yellow}m--"
+    assert_line --index 7 --partial  "${escape}[${fg_brightgreen}m--"
+}


### PR DESCRIPTION
A patch series to incrementally expand support for git supported color settings.

1.  maint: set ansi colors in common routine
    Setting foreground and background colors is now using the same code.

1.  fix: ignore negative color attributes with tests
    The colors in the git config may have attributes and negative versions  of them (no/no- prefix).  The negative versions will no longer cause a false positive checking for the attribute.  While not immediately obvious,  upcoming support for `default`(ul) is also affected.

    A new test file is specifically for testing the settings of the ansi codes and the possible settings in the git config.
1.  fix: support git config colors  normal and default
    Normal is a placeholder and will be ignored.  Default will generate ansi codes for the default foreground or background color.

    Git validates the config so a bright prefix on these values would not be allowed.  They are added to the hash to keep the code simple.

1.  fix: support #rgb colors in git config
    Git supports diff colors in #rrggbb notation.   diff-so-fancy now supports them as well.

Some of the functions and constants in the head of test file `git-config.bats` can be moved to `util.bash` if that is preferred.  They are not specific to that file.  They are helpers to allow a more generic specification of the ansi escape codes without actually having to know the specific values.