### PR TITLE
docs: fix url to Nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Vanilla `git diff` vs `git` and `diff-so-fancy`
 
 Installation is as simple as cloning this repo and then putting the `diff-so-fancy` script in to your `$PATH`. The `lib/` directory will need to be kept relative to the core script.
 
-`diff-so-fancy` is also available from the [NPM registry](https://www.npmjs.com/package/diff-so-fancy), [brew](https://formulae.brew.sh/formula/diff-so-fancy), and as a package on [Nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix), [Fedora](https://packages.fedoraproject.org/pkgs/diff-so-fancy/diff-so-fancy/), in the [Arch community repo](https://archlinux.org/packages/community/any/diff-so-fancy/), [Gentoo Guru](https://github.com/gentoo/guru/tree/master/app-misc/diff-so-fancy), [ppa:aos for Debian/Ubuntu Linux](https://github.com/aos/dsf-debian).
+`diff-so-fancy` is also available from the [NPM registry](https://www.npmjs.com/package/diff-so-fancy), [brew](https://formulae.brew.sh/formula/diff-so-fancy), and as a package on [Nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/diff-so-fancy/default.nix), [Fedora](https://packages.fedoraproject.org/pkgs/diff-so-fancy/diff-so-fancy/), in the [Arch community repo](https://archlinux.org/packages/community/any/diff-so-fancy/), [Gentoo Guru](https://github.com/gentoo/guru/tree/master/app-misc/diff-so-fancy), [ppa:aos for Debian/Ubuntu Linux](https://github.com/aos/dsf-debian).
 
 Issues relating to packaging ('installation does not work', 'version is out of date', etc.) should be directed to those packages' own repositories/issue trackers where applicable.
 


### PR DESCRIPTION
Nix URL seems to [have been changed](https://github.com/NixOS/nixpkgs/commit/d994dabacef6a7e13a41d144cd6d800f8e21a11f):

* old : https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
* new: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/diff-so-fancy/default.nix