### PR TITLE
Update less invocation as of version 530

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Issues relating to packaging ('installation does not work', 'version is out of d
 Configure git to use `diff-so-fancy` for all diff output:
 
 ```shell
-git config --global core.pager "diff-so-fancy | less --tabs=4 -RFX"
+git config --global core.pager "diff-so-fancy | less --tabs=4 -RF"
 git config --global interactive.diffFilter "diff-so-fancy --patch"
 ```
 


### PR DESCRIPTION
As of `less` [version 530][1] the `-F` flag no longer outputs the terminal init sequence if the output is less than one screen. This means `less -F` (without `-X`) will act similarly to `cat` and just print the output to the screen.

[1]: http://www.greenwoodsoftware.com/less/news.530.html