### PR TITLE
Make this loadable easily by ZSH frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Vanilla `git diff` vs `git` and `diff-so-fancy`
 
 Installation is as simple as cloning this repo and then putting the `diff-so-fancy` script in to your `$PATH`. The `lib/` directory will need to be kept relative to the core script.
 
+If you are using a ZSH framework like [zgenom](https://github.com/jandamm/zgenom) or [oh-my-zsh](https://ohmyz.sh), refer to [ZSH framework install](zsh-frameworks.md) for detailed installation instructions.
+
 `diff-so-fancy` is also available from the [NPM registry](https://www.npmjs.com/package/diff-so-fancy), [brew](https://formulae.brew.sh/formula/diff-so-fancy), as a package on [Nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/diff-so-fancy/default.nix), [Fedora](https://packages.fedoraproject.org/pkgs/diff-so-fancy/diff-so-fancy/), in the [Arch extra repo](https://archlinux.org/packages/extra/any/diff-so-fancy/), and as [ppa:aos for Debian/Ubuntu Linux](https://github.com/aos/dsf-debian).
 
 Issues relating to packaging ('installation does not work', 'version is out of date', etc.) should be directed to those packages' own repositories/issue trackers where applicable.

--- a/diff-so-fancy.plugin.zsh
+++ b/diff-so-fancy.plugin.zsh
@@ -1,0 +1,12 @@
+# Add our plugin diretory to user's path
+#
+# See following web page for explanation of the line "ZERO=...":
+# https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+
+0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+local diff_so_fancy_bin="${0:h}"
+
+if [[ -z "${path[(r)${diff_so_fancy_bin}]}" ]]; then
+    path+=( "${diff_so_fancy_bin}" )
+fi

--- a/pro-tips.md
+++ b/pro-tips.md
@@ -45,22 +45,27 @@ between files with `n`/`N` keys:
     diff = diff-so-fancy | less --tabs=4 -RFXS --pattern '^(Date|added|deleted|modified): '
 ```
 
-## Zsh plugin providing diff-so-fancy
+## Zsh plugin suppport for diff-so-fancy
 
-Zsh plugin [zdharma-continuum/zsh-diff-so-fancy](https://github.com/zdharma-continuum/zsh-diff-so-fancy) has this
-project as a submodule, so installing the plugin installs `diff-so-fancy`. The plugin provides
-the subcommand `git dsf` out of the box. Installation with Zinit, Zplug, and Zgen:
+This project includes a `.plugin.zsh` file providing ZSH framework support, so you can use any framework that supports the ZSH plugin standard to install `diff-so-fancy` and add it to your `$PATH`. Installation with Zinit, Zplug, and Zgen:
 
-```zsh
-# zinit
+### Install with zinit
+
+```sh
 zinit ice lucid as"program" pick"bin/git-dsf"
-zinit load zdharma-continuum/zsh-diff-so-fancy
+zinit load so-fancy/diff-so-fancy
+```
 
-# zplug
-zplug "zdharma-continuum/zsh-diff-so-fancy", as:command, use:bin/git-dsf
+### Install with zplug
 
-# zgen and others
-zgen zdharma-continuum/zsh-diff-so-fancy
+```sh
+zplug "so-fancy/diff-so-fancy", as:command, use:bin/git-dsf
+```
+
+# zgenom and others
+
+```sh
+zgenom load so-fancy/diff-so-fancy
 ```
 
 ## `hg` configuration


### PR DESCRIPTION
Let `zsh` users with frameworks use the framework to automatically clone the repostitory and add it to their `$PATH` so that the frameworks can keep the `git` checkout up to date.