### PR TITLE
fix: Incorrect incorrect title in pro-tips.md

### DIFF
--- a/pro-tips.md
+++ b/pro-tips.md
@@ -62,7 +62,7 @@ zinit load so-fancy/diff-so-fancy
 zplug "so-fancy/diff-so-fancy", as:command, use:bin/git-dsf
 ```
 
-# zgenom and others
+### zgenom and others
 
 ```sh
 zgenom load so-fancy/diff-so-fancy


### PR DESCRIPTION
"zgenom and others" should be in a level three heading, as "Install with zinit" and "Install with zplug" are also in a third level building.