### PR TITLE
enhancement with section header char for locating and control options about the ruler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+diff-so-fancy-standalone

--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ Use this setting to set the width of the file header manually.
 git config --global diff-so-fancy.rulerWidth 80
 ```
 
+### hideTopRuler and hideBottomRuler
+
+By default, show both top & bottom horizontal ruler.
+
+```bash
+git config --bool --global diff-so-fancy.hideTopRuler    false
+git config --bool --global diff-so-fancy.hideBottomRuler false
+
+# __OR__ use the command line options to hide the ruler
+diff-so-fancy -U # hide top ruler, -U is short for --no-thr
+diff-so-fancy -D # hide bottom ruler, -D is short for --no-bhr
+
+# __OR__ use the command line options to show the ruler
+diff-so-fancy -u # show top ruler, -u is short for --show-thr
+diff-so-fancy -d # show bottom ruler, -d is short for --show-bhr
+```
+
+**NOTE** the priority (show)`-u/-d` > (hide)`-U/-D` > `hideTopRuler/hideBottomRuler`
+
+- if default config to **show**, it is easy to hide it use cmd args of `-U/-D`
+- if default config to **hide**, it is easy to show it use cmd args of `-u/-d`
+
 ### sectionChar
 
 By default, the section char is set to unicode wide char `◯`, If this is causing

--- a/README.md
+++ b/README.md
@@ -137,6 +137,32 @@ diff-so-fancy -d # show bottom ruler, -d is short for --show-bhr
 - if default config to **show**, it is easy to hide it use cmd args of `-U/-D`
 - if default config to **hide**, it is easy to show it use cmd args of `-u/-d`
 
+By default, if a ruler is to hide, then it will be replaced by an newline.
+
+- A: if a ruler is going to hide, then make it replaced by an newline
+  * This is controled by `-x`, the default is **ON**
+- B: if a ruler is to be showing, then make it replaced by an newline
+  * This is controled by `-X`, the default is **OFF**
+
+```bash
+# -X tells to replace both showing ruler with newline
+diff-so-fancy -X        ### both rulers are newline ###
+# -X make showing bottom newline, -U make hidding top newline
+diff-so-fancy -X -U     ### both rulers are newline ###
+# -X make showing top newline, -U make hidding bottom newline
+diff-so-fancy -X -D     ### both rulers are newline ###
+
+# -X make showing bottom newline, -U -x make top completely hidding
+diff-so-fancy -X -U -x  # no top ruler, bottom ruler newline
+diff-so-fancy -x -U     # no top ruler, bottom ruler dash
+
+# -X make showing top newline, -D -x make bottom completely hidding
+diff-so-fancy -X -D -x  # no bottom ruler, top ruler newline
+diff-so-fancy -x -D     # no bottom ruler, top ruler dash
+
+diff-so-fancy -x -U -D  # completely hide both ruler at all
+```
+
 ### sectionChar
 
 By default, the section char is set to unicode wide char `◯`, If this is causing

--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ diff-so-fancy --use-sc "DIFF" # set to any chars you like
 diff-so-fancy -N # none, -N is short for --no-section-char
 ```
 
-$section_char
-
 ## The diff-so-fancy team
 
 | Person                | Role             |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ git config --bool --global diff-so-fancy.stripLeadingSymbols false
 
 ### useUnicodeRuler
 
-By default, the separator for the file header uses Unicode line-drawing characters. If this is causing output errors on your terminal, set this to `false` to use ASCII characters instead. (Default: true)
+By default, the separator for the file header uses Unicode line-drawing characters.
+If this is causing output errors on your terminal, set this to `false` to use
+ASCII characters instead. (Default: true)
 
 ```shell
 git config --bool --global diff-so-fancy.useUnicodeRuler false
@@ -106,11 +108,28 @@ git config --bool --global diff-so-fancy.useUnicodeRuler false
 
 ### rulerWidth
 
-By default, the separator for the file header spans the full width of the terminal. Use this setting to set the width of the file header manually.
+By default, the separator for the file header spans the full width of the terminal.
+Use this setting to set the width of the file header manually.
 
 ```shell
 git config --global diff-so-fancy.rulerWidth 80
 ```
+
+### sectionChar
+
+By default, the section char is set to unicode wide char `◯`, If this is causing
+output errors on your terminal, then you can reset it to other char or make it
+completely none.
+
+```bash
+git config --global diff-so-fancy.sectionChar ""   # set to none
+git config --global diff-so-fancy.sectionChar "DIFF" # set to DIFF
+# __OR__ use the command line options
+diff-so-fancy --use-sc "DIFF" # set to any chars you like
+diff-so-fancy -N # none, -N is short for --no-section-char
+```
+
+$section_char
 
 ## The diff-so-fancy team
 

--- a/build-standalone.sh
+++ b/build-standalone.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function has-cmd() {  command -v "$1" > /dev/null; }
+function no-cmd() { ! command -v "$1" > /dev/null; }
+
+if no-cmd fatpack && has-cmd apt; then
+  sudo apt install libapp-fatpacker-perl
+fi
+
+THIS_DIR="$(git rev-parse --show-toplevel)"
+OUTPUT="${THIS_DIR}/diff-so-fancy-standalone"
+
+${THIS_DIR}/third_party/build_fatpack/build.pl --output "${OUTPUT}"

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -54,6 +54,11 @@ my $color_forced      = 0; # Has the color been forced on/off
 my $show_top_ruler = 1;
 my $show_bot_ruler = 1;
 
+# The ruler is an empty newline, not dash
+my $ruler_is_newline_if_no_hide = 0;
+# The ruler is an empty newline only if it is to be hidden
+my $ruler_is_newline_hide_only = 1;
+
 # We try and be smart about whether we need to do line coloring, but
 # this is an option to force it on/off
 if ($args->{color_on}) {
@@ -122,17 +127,41 @@ if ($args->{d} || $args->{'show-bhr'}) {
 	$show_bot_ruler = 1;
 }
 
+if ($args->{x}) {
+	$ruler_is_newline_hide_only = 0;
+}
+
+if ($args->{X}) {
+	$ruler_is_newline_if_no_hide = 1;
+}
+
 sub draw_top_ruler($) {
 	my ($ruler_color) = @_;
 	if ($show_top_ruler) {
-		print horizontal_rule($ruler_color);
+		if ($ruler_is_newline_if_no_hide) {
+			print "\n";
+		} else {
+			print horizontal_rule($ruler_color);
+		}
+	} else {
+		if ($ruler_is_newline_hide_only) {
+			print "\n";
+		}
 	}
 }
 
 sub draw_bot_ruler($) {
 	my ($ruler_color) = @_;
 	if ($show_bot_ruler) {
-		print horizontal_rule($ruler_color);
+		if ($ruler_is_newline_if_no_hide) {
+			print "\n";
+		} else {
+			print horizontal_rule($ruler_color);
+		}
+	} else {
+		if ($ruler_is_newline_hide_only) {
+			print "\n";
+		}
 	}
 }
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -789,11 +789,29 @@ diff-so-fancy --colors                   # View the commands to set the recommen
 diff-so-fancy --set-defaults             # Configure git-diff to use diff-so-fancy and suggested colors
 diff-so-fancy --patch                    # Use diff-so-fancy in patch mode (interoperable with `git add --patch`)
 
+diff-so-fancy -N                         # No section-chars, default is ◯
+diff-so-fancy --use-sc 'DIFF'            # Customizing the section-chars
+
 # Configure git to use d-s-f for *all* diff operations
 git config --global core.pager \"diff-so-fancy | less --tabs=4 -RFX\"
 
 # Configure git to use d-s-f for `git add --patch`
-git config --global interactive.diffFilter \"diff-so-fancy --patch\"\n";
+git config --global interactive.diffFilter \"diff-so-fancy --patch\"
+
+More Ruler Control Arguments:
+
+By default, both top/bottom ruler is showing, and use Unicode line-drawing char.
+And the if ruler is hiding then replace it by newline flag is set ON by default.
+
+  -U  Mark the top ruler to hiding when drawing
+  -u  Mark the top ruler to showing when drawing
+  -D  Mark the bottom ruler to hiding when drawing
+  -d  Mark the bottom ruler to showing when drawing
+
+  -x  If ruler is marked hiding, then replace it by newline, default ON
+  -X  If ruler is marked showing, then replace it by newline, default OFF
+
+";
 
 	return $out;
 }

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -23,6 +23,8 @@ my $change_hunk_indicators     = git_config_boolean("diff-so-fancy.changeHunkInd
 my $strip_leading_indicators   = git_config_boolean("diff-so-fancy.stripLeadingSymbols","true");
 my $mark_empty_lines           = git_config_boolean("diff-so-fancy.markEmptyLines","true");
 my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRuler","true");
+my $hide_top_ruler             = git_config_boolean("diff-so-fancy.hideTopRuler","false");
+my $hide_bot_ruler             = git_config_boolean("diff-so-fancy.hideBottomRuler","false");
 my $ruler_width                = git_config("diff-so-fancy.rulerWidth", undef);
 my $section_char               = git_config("diff-so-fancy.sectionChar", "◯  ");
 my $git_strip_prefix           = git_config_boolean("diff.noprefix","false");
@@ -47,6 +49,10 @@ my $in_hunk           = 0;
 my $columns_to_remove = 0;
 my $is_mercurial      = 0;
 my $color_forced      = 0; # Has the color been forced on/off
+
+# Default show top & bottom ruler
+my $show_top_ruler = 1;
+my $show_bot_ruler = 1;
 
 # We try and be smart about whether we need to do line coloring, but
 # this is an option to force it on/off
@@ -96,6 +102,38 @@ if ($args->{N} || $args->{'no-section-char'}) {
 	$section_char = '';
 } elsif ($args->{'use-sc'}) {
 	$section_char = $args->{'use-sc'};
+}
+
+# hide up/top horizontal ruler
+if ($args->{U} || $args->{'no-thr'} || $hide_top_ruler) {
+	$show_top_ruler = 0;
+}
+# hide down/bottom horizontal ruler
+if ($args->{D} || $args->{'no-bhr'} || $hide_bot_ruler) {
+	$show_bot_ruler = 0;
+}
+
+# show up/top horizontal ruler
+if ($args->{u} || $args->{'show-thr'}) {
+	$show_top_ruler = 1;
+}
+# show down/bottom horizontal ruler
+if ($args->{d} || $args->{'show-bhr'}) {
+	$show_bot_ruler = 1;
+}
+
+sub draw_top_ruler($) {
+	my ($ruler_color) = @_;
+	if ($show_top_ruler) {
+		print horizontal_rule($ruler_color);
+	}
+}
+
+sub draw_bot_ruler($) {
+	my ($ruler_color) = @_;
+	if ($show_bot_ruler) {
+		print horizontal_rule($ruler_color);
+	}
 }
 
 #################################################################################
@@ -198,9 +236,9 @@ sub do_dsf_stuff {
 			}
 
 			if ($file_1 && $file_2) {
-				print horizontal_rule($meta_color);
+				draw_top_ruler($meta_color);
 				print $meta_color . file_change_string($file_1,$file_2) . "\n";
-				print horizontal_rule($meta_color);
+				draw_bot_ruler($meta_color);
 			}
 		#########################
 		# Look for the filename #
@@ -255,7 +293,7 @@ sub do_dsf_stuff {
 
 			# Print out the top horizontal line of the header
 			print $reset_color;
-			print horizontal_rule($meta_color);
+			draw_top_ruler($meta_color);
 
 			# Mercurial coloring is slightly different so we need to hard reset colors
 			if ($is_mercurial) {
@@ -266,7 +304,7 @@ sub do_dsf_stuff {
 			print file_change_string($file_1,$file_2) . "\n";
 
 			# Print out the bottom horizontal line of the header
-			print horizontal_rule($meta_color);
+			draw_bot_ruler($meta_color);
 		########################################
 		# Check for "@@ -3,41 +3,63 @@" syntax #
 		########################################
@@ -337,9 +375,9 @@ sub do_dsf_stuff {
 		################################
 		} elsif ($line =~ /^Binary files (\w\/)?(.+?) and (\w\/)?(.+?) differ/) {
 			my $change = file_change_string($2,$4);
-			print horizontal_rule($meta_color);
+			draw_top_ruler($meta_color);
 			print "$meta_color$change (binary)\n";
-			print horizontal_rule($meta_color);
+			draw_bot_ruler($meta_color);
 		#####################################################
 		# Check if we're changing the permissions of a file #
 		#####################################################
@@ -383,9 +421,9 @@ sub do_dsf_stuff {
 
 				my $change = file_change_string($file1,$file2);
 
-				print horizontal_rule($meta_color);
+				draw_top_ruler($meta_color);
 				print $meta_color . $change . "\n";
-				print horizontal_rule($meta_color);
+				draw_bot_ruler($meta_color);
 			}
 
 			$i += 3; # We've consumed three lines

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -24,6 +24,7 @@ my $strip_leading_indicators   = git_config_boolean("diff-so-fancy.stripLeadingS
 my $mark_empty_lines           = git_config_boolean("diff-so-fancy.markEmptyLines","true");
 my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRuler","true");
 my $ruler_width                = git_config("diff-so-fancy.rulerWidth", undef);
+my $section_char               = git_config("diff-so-fancy.sectionChar", "◯  ");
 my $git_strip_prefix           = git_config_boolean("diff.noprefix","false");
 my $has_stdin                  = has_stdin();
 my $CONTEXT_LINES              = undef; # Number of lines of context diff used
@@ -89,6 +90,12 @@ if (!$has_stdin) {
 	} else {
 		die("Missing input on STDIN\n");
 	}
+}
+
+if ($args->{N} || $args->{'no-section-char'}) {
+	$section_char = '';
+} elsif ($args->{'use-sc'}) {
+	$section_char = $args->{'use-sc'};
 }
 
 #################################################################################
@@ -645,25 +652,25 @@ sub file_change_string {
 
 	# If they're the same it's a modify
 	if ($file_1 eq $file_2) {
-		return "modified: $file_1";
+		return $section_char . "modified: $file_1";
 	# If the first is /dev/null it's a new file
 	} elsif ($file_1 eq "/dev/null") {
 		my $add_color = $DiffHighlight::NEW_HIGHLIGHT[1];
-		return "added: $add_color$file_2$reset_color";
+		return $section_char . "added: $add_color$file_2$reset_color";
 	# If the second is /dev/null it's a deletion
 	} elsif ($file_2 eq "/dev/null") {
 		my $del_color = $DiffHighlight::OLD_HIGHLIGHT[1];
-		return "deleted: $del_color$file_1$reset_color";
+		return $section_char . "deleted: $del_color$file_1$reset_color";
 	# If the files aren't the same it's a rename
 	} elsif ($file_1 ne $file_2) {
 		my ($old, $new) = DiffHighlight::highlight_pair($file_1,$file_2,{only_diff => 1});
 		# highlight_pair already includes reset_color, but adds newline characters that need to be trimmed off
 		$old = trim($old);
 		$new = trim($new);
-		return "renamed: $old$meta_color to $new"
+		return $section_char . "renamed: $old$meta_color to $new"
 	# Something we haven't thought of yet
 	} else {
-		return "$file_1 -> $file_2";
+		return $section_char . "$file_1 -> $file_2";
 	}
 }
 


### PR DESCRIPTION
- add section header char, thus the section can be located
  * make `diff-so-fancy` works together with [ov](https://github.com/noborus/ov) with more pertty output
  * add two options, `-use-sc` **DIFF** for customization, `-N` to reset/clean it
- add options to control the ruler type
  By default, top/bottom ruler is showing with unicode line-drawing chars.
  And if a ruler is marked to hiding, by default it will be replaced by newline.
  * `-U` mark top ruler to hiding, and `-u` make top ruler to showing
  * `-D` mark bottom ruler to hiding, and `-d` make bottom ruler to showing
  * `-X` mark showing ruler to be replaced with newline
  * `-x` mark hiding ruler to be replaced with newline
 
More examples and details can be found in README.md