### PR TITLE
Make first 16 color bars narrower to avoid wrapping

### DIFF
--- a/third_party/term-colors/term-colors.pl
+++ b/third_party/term-colors/term-colors.pl
@@ -20,6 +20,7 @@ if ($perl && has_term_ansicolor(4.0)) {
 	#print "TERM::ANSIColor constant names:\n";
 	term_ansicolor();
 } else {
+	my $padding = 2;
 	my $section  = 1;
 	my $grouping = 8;
 
@@ -28,11 +29,10 @@ if ($perl && has_term_ansicolor(4.0)) {
 
 		if (needs_white($i)) {
 			print set_fcolor(15); # White
-			printf("    %03d    ",$i); # Ouput the color number in white
 		} else {
 			print set_fcolor(0); # Black
-			printf("    %03d    ",$i); # Ouput the color number in black
 		}
+		printf(" " x $padding . "%03d" . " " x $padding,$i);
 
 		print set_fcolor(); # Reset both colors
 		print "  ";         # Seperator
@@ -42,6 +42,7 @@ if ($perl && has_term_ansicolor(4.0)) {
 			print "\n\n";
 			$section  = 0;
 			$grouping = 6;
+			$padding = 4;
 		} elsif ($section > 0 && ($section % $grouping == 0)) {
 			print set_bcolor(); # Reset
 			print "\n";


### PR DESCRIPTION
Text wrapping inside color is better to avoid because some terminals set next line default colors based on the current color. I think we can assume that default terminal width is 80 and avoid any kind of magic to fit all lines to terminal width.
 
This is how it looks at 80x24 xterm before

![Flameshot_2025-02-27_17-17-46-23](https://github.com/user-attachments/assets/180f93fd-9828-484e-96f8-ea92df8998e7)

and after this change

![Flameshot_2025-02-27_17-17-45-38](https://github.com/user-attachments/assets/10a921cb-bc19-4182-bcb3-15f56a9da0f8)
