### PR TITLE
npm trusted publish & docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,15 +25,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install and Build
         run: |
-          npm ci
           npm run build
 
       - name: Publish to npm
         run: |
-          npm install -g npm@latest
           npm publish --provenance --access public --registry https://registry.npmjs.org/

--- a/hacking-and-testing.md
+++ b/hacking-and-testing.md
@@ -33,7 +33,18 @@ When writing assertions, you'll likely want to compare to expected output. To gr
 
 ### Publishing to npm
 
-Run these one-by-one, manually.
+
+Now mostly automated (hopefully) thanks to [npm github provenance trusted publishing](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions).  See [publish.yml](./.github/workflows/publish.yml)
+
+1. Update `package.json`'s version when bumping library version.
+2. Set git tag only after package.json's version is updated.
+3. Push the tag.
+4. Rest of the npm package publish should be automatic. Watch [gh actions](https://github.com/so-fancy/diff-so-fancy/actions) for the publish workflow.
+
+
+
+#### Old manual instructions
+
 
 ```sh
 diff-so-fancy --version # see the old version (probably)


### PR DESCRIPTION
used my newly drafted https://github.com/paulirish/dotfiles/blob/main/agents/paulirish-skills/skills/npm-trusted-publishing/SKILL.md for this! :)  lovely.


---

@scottchiefbaker 

I snuck in https://github.com/so-fancy/diff-so-fancy/blob/next/.github/workflows/publish.yml without PR fyi.

This setup _should_ work but its possible it doesn't. We'll find out on next version tag if I need to tweak it again.

The main thing is setting the package.json version before the git tag.  (We could also update that version as part of the build script, though its possible that breaks this provenance thing.  Probably fine though.)