### PR TITLE
Link install instructions to releases page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vanilla `git diff` vs `git` and `diff-so-fancy`
 
 ## 📦 Install
 
-Simply copy the `diff-so-fancy` script from the latest Github release into your `$PATH` and you're done. Alternately to test development features you can clone this repo and then put the `diff-so-fancy` script (symlink will work) into your `$PATH`. The `lib/` directory will need to be kept relative to the core script.
+Simply copy the `diff-so-fancy` script from the latest [Github release](https://github.com/so-fancy/diff-so-fancy/releases) into your `$PATH` and you're done. Alternately to test development features you can clone this repo and then put the `diff-so-fancy` script (symlink will work) into your `$PATH`. The `lib/` directory will need to be kept relative to the core script.
 
 `diff-so-fancy` is also available from the [NPM registry](https://www.npmjs.com/package/diff-so-fancy), [brew](https://formulae.brew.sh/formula/diff-so-fancy), [Fedora](https://packages.fedoraproject.org/pkgs/diff-so-fancy/diff-so-fancy/), in the [Arch extra repo](https://archlinux.org/packages/extra/any/diff-so-fancy/), and as [ppa:aos for Debian/Ubuntu Linux](https://github.com/aos/dsf-debian).
 


### PR DESCRIPTION
I thought the instructions meant I should copy the top-level file "diff-so-fancy" from the latest released commit. That didn't work. I learned what I was supposed to do by reading https://github.com/so-fancy/diff-so-fancy/issues/318 . I hope this change will save someone like me a bit of time. (I guess if I spent more time using GitHub I would have understood what "Github release" meant.)