### PR TITLE
Fix spelling mistake in code comment

### DIFF
--- a/diff-so-fancy.plugin.zsh
+++ b/diff-so-fancy.plugin.zsh
@@ -1,4 +1,4 @@
-# Add our plugin diretory to user's path
+# Add our plugin directory to user's path
 #
 # See following web page for explanation of the line "ZERO=...":
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html


### PR DESCRIPTION
As straightforward as it gets! Changed `diretory` to `directory`.

Also, looks like GitHub's online editor added a trailing newline. 🤷🏻 