### PR TITLE
Suppress Perl warning for 'use_color' variable in Dump::Krumo

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1380,7 +1380,7 @@ BEGIN {
 	# If you're me you load a debug library
 	if ($ENV{USER} && ($ENV{USER} eq "bakers")) {
 		require Dump::Krumo;
-		$Dump::Krumo::use_color = 2;
+		{ no warnings 'once'; $Dump::Krumo::use_color = 2; }
 		Dump::Krumo->import(qw(k kd));
 	}
 }

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1379,8 +1379,10 @@ BEGIN {
 
 	# If you're me you load a debug library
 	if ($ENV{USER} && ($ENV{USER} eq "bakers")) {
+		no warnings 'once';
+
 		require Dump::Krumo;
-		{ no warnings 'once'; $Dump::Krumo::use_color = 2; }
+		$Dump::Krumo::use_color = 2;
 		Dump::Krumo->import(qw(k kd));
 	}
 }


### PR DESCRIPTION
## Fix "used only once" Perl warning in developer debug block

### Summary

Suppresses a spurious Perl warning emitted during normal use of `diff-so-fancy`:

```
Name "Dump::Krumo::use_color" used only once: possible typo at diff-so-fancy line 1383.
```

### What changed and why

The assignment `$Dump::Krumo::use_color = 2` inside the developer-only debug block is the only reference to that package variable in the entire script. Perl's `warnings` pragma flags this at compile time as a potential typo, even though the block is never entered for any user other than the author.

Wrapping the assignment in a `{ no warnings 'once'; ... }` block suppresses the warning locally and lexically, without affecting any other warning behaviour in the script.


### Testing

- Verified the warning no longer appears when running `diff-so-fancy` with `perl -w`.
- No functional behaviour is changed. The debug block is unaffected for the intended user.

Closes #526