### PR TITLE
Fix broken link to sem project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ git config --global diff-so-fancy.shortHeaders true
 
 ### semIntegration
 
-Include the summary from [sem](github.com/Ataraxy-Labs/sem) in the header
+Include the summary from [sem](https://github.com/Ataraxy-Labs/sem) in the header
 for each changed file. (Default false)
 
 ```shell


### PR DESCRIPTION
Hello,

The link to the https://github.com/Ataraxy-Labs/sem project in `README.md` is missing an `https://` scheme, and as a result is interpreted as a relative link. It resolves to
```
https://github.com/so-fancy/diff-so-fancy/blob/next/github.com/Ataraxy-Labs/sem
```

which gives a 404.