### PR TITLE
Fix patch mode line mismatch on added/deleted files

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -164,12 +164,14 @@ sub do_dsf_stuff {
 	my $input     = shift();
 	my $chunk_str = join("", @$input); # Store the full chunk text for lookbacks
 
-	# FIXME: There is a scenario where there are FIVE diff header lines
-	# I'm not sure if we need to account for that or not. Unit tests pass so... bees?
+	# git requires interactive.diffFilter output to stay 1:1 with input. Add/delete
+	# with content have 3 header lines (not 4) but still need balancing; empty ones (no @@) don't.
 	my $cnt = count_git_header_lines(@$input);
-	if ($cnt == 4) {
+	if ($cnt == 4 || ($cnt == 3 && grep { /^${ansi_color_regex}@@/ } @$input)) {
 		$patch_mode    = 1;
 		$short_headers = 0; # shortHeaders has to be off in --patch mode
+	} else {
+		$patch_mode    = 0;
 	}
 
 	# If we don't see ANY ANSI in the chunk we enable manual coloring mode

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -113,3 +113,20 @@ teardown_file() {
 	assert_line --index 6 --regexp "^\[COLOR227\]──────────────────────────┐"
 	assert_line --index 8 --regexp "^\[COLOR227\]──────────────────────────┘"
 }
+
+@test "Patch mode line count matches on add/delete" {
+	for fixture in add_file_with_content delete_file_with_content; do
+		local in out
+		in=$( load_fixture "$fixture" | wc -l )
+		out=$( load_fixture "$fixture" | $diff_so_fancy --patch | wc -l )
+		[ "$in" -eq "$out" ] || fail "fixture '$fixture': $in input lines but $out output lines"
+	done
+
+	for fixture in add_empty_file remove_empty_file; do
+		local bare in out
+		bare=$( load_fixture "$fixture" | sed -n '/^diff --git/,$p' )
+		in=$( printf '%s\n' "$bare" | wc -l )
+		out=$( printf '%s\n' "$bare" | $diff_so_fancy --patch | wc -l )
+		[ "$in" -eq "$out" ] || fail "fixture '$fixture' (bare): $in input lines but $out output lines"
+	done
+}

--- a/test/fixtures/add_file_with_content.diff
+++ b/test/fixtures/add_file_with_content.diff
@@ -1,0 +1,9 @@
+diff --git a/newfile.txt b/newfile.txt
+new file mode 100644
+index 0000000..0c2aa38
+--- /dev/null
++++ b/newfile.txt
+@@ -0,0 +1,3 @@
++line one
++line two
++line three

--- a/test/fixtures/delete_file_with_content.diff
+++ b/test/fixtures/delete_file_with_content.diff
@@ -1,0 +1,9 @@
+diff --git a/oldfile.txt b/oldfile.txt
+deleted file mode 100644
+index 0c2aa38..0000000
+--- a/oldfile.txt
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line one
+-line two
+-line three


### PR DESCRIPTION
Using diff-so-fancy as an `interactive.diffFilter` (`git add -p`) currently fails with:
```
error: mismatched output from interactive.diffFilter
hint: Your filter must maintain a one-to-one correspondence
hint: between its input and output lines.
```
whenever a file is added or deleted with content. git requires the filter to emit exactly one output line per input line, and diff-so-fancy was dropping the newlines it uses to keep that 1:1 ratio.
