### PR TITLE
Fix crash on git dates without a timezone offset

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1545,6 +1545,11 @@ sub git_datestr_unixtime {
 		return "";
 	}
 
+	# git's --date=local (and log.date=local) omit the timezone offset, so
+	# treat that as an already-local time with a zero offset instead of
+	# dying on the undefined value below (warnings are fatal in this file).
+	$tz //= 0;
+
 	# Convert local time to UTC using timezone offset like -700
 	my $offset_hours   = int($tz / 100);
 	my $offset_minutes = abs($tz % 100);


### PR DESCRIPTION
To reproduce:

```
git init repo && cd repo
git commit --allow-empty -m "test"
git -c log.date=local show --color=always | diff-so-fancy
```

**Expected:** the commit metadata prints normally, with a human readable "(N ago)" annotation appended to the `Date:` line.

**Actual:** diff-so-fancy dies right after printing the `Author:` line, before the `Date:` line is even reached:

```
Use of uninitialized value $tz in division (/) at diff-so-fancy line 1549, <STDIN> line 5.
```

Seems to have been introduced in [382ff82](https://github.com/so-fancy/diff-so-fancy/blob/382ff82f1efffb4d040e0b4daf37e85f445f4569/diff-so-fancy#L1533-L1536). Related to #540, which reported the a similar crash for `log.date=iso`.

Cause: `git_datestr_unixtime()` matches the date line's prefix with a regex, then destructures `$wday, $mon_str, $mday, $hour, $min, $sec, $year, $tz` from the split fields. `log.date=local` (and `--date=local`) omit the trailing timezone field, so the split returns one fewer element and `$tz` comes back undefined. That reaches `int($tz / 100)` a few lines later, and since the script runs with `use warnings FATAL => 'all'`, the "uninitialized value" warning is fatal instead of just noise.

Fix: default `$tz` to `0` when the date string has no timezone field.
