### PR TITLE
Add diff-so-fancy.fileNameRulerShape

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ rulerWidth sets the width of the ruler lines. (Default: screen width)
 git config --global diff-so-fancy.rulerWidth 80
 ```
 
+### fileNameRulerShape
+
+Shape of the ruler drawn around file names in `git show` output. Set this to
+`ruler` to use full width ruler lines instead of boxes. (Default: box)
+
+```shell
+git config --global diff-so-fancy.fileNameRulerShape ruler
+```
+
 ### shortHeaders
 
 Simplify the header information to a *single* line for filename and line

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -33,6 +33,7 @@ my $strip_leading_indicators   = git_config_boolean("diff-so-fancy.stripLeadingS
 my $mark_empty_lines           = git_config_boolean("diff-so-fancy.markEmptyLines","true");
 my $use_unicode_dash_for_ruler = git_config_boolean("diff-so-fancy.useUnicodeRuler","true");
 my $ruler_width                = git_config("diff-so-fancy.rulerWidth", undef);
+my $file_name_ruler_shape      = lc(git_config("diff-so-fancy.fileNameRulerShape","box")) eq 'ruler' ? 'ruler' : 'box';
 my $git_strip_prefix           = git_config_boolean("diff.noprefix","false");
 my $do_sem_stuff               = git_config_boolean("diff-so-fancy.semIntegration","false");
 my $has_stdin                  = has_stdin();
@@ -294,8 +295,8 @@ sub do_dsf_stuff {
 			$meta_color    = $1;
 			$git_show_mode = 1;
 
-			# Rulers after this (file names) are in a box
-			$ruler_shape = 'box';
+			# Rulers after this (file names) are in a box (see diff-so-fancy.fileNameRulerShape)
+			$ruler_shape = $file_name_ruler_shape;
 
 			draw_ruler($line, "ruler", $meta_color);
 		################################################
@@ -1772,6 +1773,10 @@ B<useUnicodeRuler:> Use Unicode to draw the ruler lines. Setting this to false w
 B<rulerWidth:> rulerWidth sets the width of the ruler lines. (Default: screen width)
 
     git config --global diff-so-fancy.rulerWidth 80
+
+B<fileNameRulerShape:> Shape of the ruler drawn around file names in C<git show> output. Set this to C<ruler> to use full width ruler lines instead of boxes. (Default: box)
+
+    git config --global diff-so-fancy.fileNameRulerShape ruler
 
 B<shortHeaders:> Simplify the header information to a single line for filename and line number. (Default false)
 

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -248,6 +248,20 @@ teardown_file() {
 	assert_line --index 1 --regexp 'deleted: .*@ 1'
 }
 
+@test "In 'git show' mode fileNameRulerShape switches file name boxes to rulers" {
+	# By default the file names are drawn in a box
+	output=$( load_fixture "gitshow" | $diff_so_fancy | $ansi_reveal)
+	run printf "%s" "$output"
+	assert_line --index 6 --partial "┐"
+
+	# With fileNameRulerShape=ruler they are drawn as full width rulers
+	git config --file "$(dsf_test_git_config)" diff-so-fancy.fileNameRulerShape ruler
+	output=$( load_fixture "gitshow" | $diff_so_fancy | $ansi_reveal)
+	git config --file "$(dsf_test_git_config)" --unset diff-so-fancy.fileNameRulerShape
+	run printf "%s" "$output"
+	refute_line --index 6 --partial "┐"
+}
+
 @test "In 'git show' mode we add a human time to the date" {
 	output=$( load_fixture "gitshow" | $diff_so_fancy | $ansi_reveal)
 	run printf "%s" "$output"


### PR DESCRIPTION
Closes #522.

Adds `diff-so-fancy.fileNameRulerShape`, using the option name @mzimnn proposed in the issue:

```shell
git config --global diff-so-fancy.fileNameRulerShape ruler
```

```
box (default)              ruler
────────────────┐          ────────────────────────────────────────────────────
modified: f.txt │          modified: f.txt
────────────────┘          ────────────────────────────────────────────────────
```

The motivation from the thread is that box width follows the file name, so a commit touching many files renders ragged, while the ruler is always full width.

## Implementation

Two lines of behavior. The `git show` branch already set `$ruler_shape = 'box'` unconditionally; it now takes the configured value, read through the same `git_config()` helper as `rulerWidth`. `draw_ruler` itself is untouched.

Anything that isn't `ruler` (case-insensitively) falls back to `box`. That matters more than it looks: `draw_ruler`'s `if/elsif` has no `else`, so an unrecognized shape would silently print *nothing*. Checked with an empty string, `banana`, `RULER`, `box` and unset.

## Default is unchanged

Not just asserted — I ran the original and patched scripts over all 36 fixtures and diffed the output. stdout is byte-identical across every one. (The only difference anywhere is a line number inside a pre-existing Perl warning on `latin1.diff`, shifted by one because the file gained a line.)

Only `git show` is affected. Ordinary `git diff` rulers are untouched, per your note in the thread that changing those would cause riots.

## Documentation

You asked for implementation *and* documentation, so both:

- `README.md`, in the same format as the neighbouring options
- the embedded POD `=head1 OPTIONS` block, so `man diff-so-fancy` lists it too

While there I noticed a pre-existing copy/paste slip in that POD: the `shortHeaders` entry is labelled `B<rulerWidth:>`. I left it alone to keep this diff focused, but happy to fix it here or separately.

## Tests

One bats test added; `make test` goes 53 → 54 passing, 0 failures. Verified load-bearing against the unpatched script:

```
not ok 50 ... refute_line --index 6 --partial "┐" failed
```

(Submodules needed `git submodule update --init --recursive` for bats to run.)
