### PR TITLE
Fix binary file parsing when the filename contains ' and '

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> $GITHUB_ENV
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           registry-url: 'https://registry.npmjs.org'
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: default build test
+
+default: build
+
+build:
+	mkdir -p dist
+	perl third_party/build_fatpack/build.pl --output dist/diff-so-fancy
+
+test:
+	./test/bats/bin/bats test

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ looking for any feedback or ideas on how to make `diff-so-fancy` even *fancier*.
 ## 🔃 Alternatives
 
 * [Delta](https://github.com/dandavison/delta)
-* [Lazygit](https://github.com/jesseduffield/lazygit) with diff-so-fancy [integration](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md#diff-so-fancy)
+* [Lazygit](https://github.com/jesseduffield/lazygit) with diff-so-fancy [integration](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_DiffRenderers.md#diff-so-fancy)
 * [difftastic](https://github.com/Wilfred/difftastic)
 
 ## 🏛️ License

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1545,9 +1545,7 @@ sub git_datestr_unixtime {
 		return "";
 	}
 
-	# git's --date=local (and log.date=local) omit the timezone offset, so
-	# treat that as an already-local time with a zero offset instead of
-	# dying on the undefined value below (warnings are fatal in this file).
+	# `--date=local` (and log.date=local) omit the timezone offset
 	$tz //= 0;
 
 	# Convert local time to UTC using timezone offset like -700

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1521,47 +1521,28 @@ sub git_datestr_unixtime {
 		return '';
 	}
 
-	my @p = split(' ', $str);
-
 	my %month = (
-		Jan => 0, Feb => 1, Mar => 2 , Apr => 3 ,
-		May => 4, Jun => 5, Jul => 6 , Aug => 7 ,
-		Sep => 8, Oct => 9, Nov => 10, Dec => 11,
+		Jan => 1, Feb => 2 , Mar => 3 , Apr => 4 ,
+		May => 5, Jun => 6 , Jul => 7 , Aug => 8 ,
+		Sep => 9, Oct => 10, Nov => 11, Dec => 12,
 	);
 
-	my ($wday, $mon_str, $mday, $time, $year, $tz, $mon);
+	my ($wday, $mon_str, $mday, $year, $tz, $mon, $hour, $min, $sec);
 
 	# Wed Jul 15 08:31:07 2026 -0700
-	if (scalar(@p) == 6) {
-		($wday, $mon_str, $mday, $time, $year, $tz) = @p;
+	if ($str =~ m/^\w{3} \w{3} \d{1,2} /) {
+		my @p = split('[ :]', $str);
+
+		($wday, $mon_str, $mday, $hour, $min, $sec, $year, $tz) = @p;
+
+		$mon = $month{$mon_str} || 0;
 	# This is --date iso: `2026-07-15 10:21:01 -0700`
-	} elsif (scalar(@p) == 3) {
-		my $date = $p[0] || "";
-		my @x    = split(/-/, $date);
+	} elsif ($str =~ m/^\d{4}-\d{2}-\d{2} /) {
+		my @p = split('[-: ]', $str, 7);
 
-		$year = $x[0] || 0;
-		$mon  = $x[1] || 0;
-		$mday = $x[2] || 0;
-
-		# For timegm months start at zero
-		if ($mon) {
-			$mon--;
-		}
-
-		$time = $p[1] || "";
-		$tz   = $p[2] || "";
+		($year, $mon, $mday, $hour, $min, $sec, $tz) = @p;
 	} else {
 		return "";
-	}
-
-	my ($hour, $min, $sec) = split /:/, $time;
-
-	if (!defined($sec)) {
-		return "";
-	}
-
-	if (!defined($mon)) {
-		$mon = $month{$mon_str} || "";
 	}
 
 	# Convert local time to UTC using timezone offset like -700
@@ -1569,9 +1550,9 @@ sub git_datestr_unixtime {
 	my $offset_minutes = abs($tz % 100);
 	my $offset_seconds = ($offset_hours * 3600) + ($offset_minutes * 60);
 
-	#print "TIME: sec=$sec min=$min hour=$hour day=$mday mon=$mon year=$year tz=$tz";
+	#print "TIME: sec=$sec min=$min hour=$hour day=$mday mon=$mon year=$year tz=$tz\n";
 
-	my $epoch = Time::Local::timegm($sec, $min, $hour, $mday, $mon, $year - 1900);
+	my $epoch = Time::Local::timegm($sec, $min, $hour, $mday, $mon - 1, $year - 1900);
 	my $ret   = $epoch - $offset_seconds;
 
 	return $ret;

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -434,8 +434,25 @@ sub do_dsf_stuff {
 		################################
 		# Look for binary file changes #
 		################################
-		} elsif ($line =~ /^Binary files (\w\/)?(.+?) and (\w\/)?(.+?) differ/) {
-			my $change = file_change_string($2,$4);
+		} elsif ($line =~ /^Binary files (.+) differ/) {
+			my $names = $1;
+
+			# a file name may itself contain " and ", so prefer the separator
+			# that is followed by the b-side prefix (or /dev/null)
+			my ($file_1,$file_2) = $names =~ /^(.+) and (\w\/.+|\/dev\/null)$/;
+			if (!defined($file_1)) {
+				($file_1,$file_2) = $names =~ /^(.+?) and (.+)$/;
+			}
+			if (!defined($file_1)) {
+				print $line;
+				$i++;
+				next;
+			}
+
+			$file_1 =~ s|^\w/||;
+			$file_2 =~ s|^\w/||;
+
+			my $change = file_change_string($file_1,$file_2);
 			my $str    = "$meta_color$change (binary)\n";
 
 			draw_ruler($str, $ruler_shape, $meta_color);

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -508,8 +508,9 @@ sub do_dsf_stuff {
 				$line = strip_leading_indicators($line,$columns_to_remove);
 			}
 
-			# Raw diffs we color manually
-			if ($manually_color_lines) {
+			# Raw diffs we color manually, but only when strip_leading_indicators
+			# hasn't already handled it
+			if ($manually_color_lines && !$strip_leading_indicators) {
 				my $first_char = substr($line, 0, 1);
 
 				if ($first_char eq "+") {

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -1545,6 +1545,11 @@ sub git_datestr_unixtime {
 		return "";
 	}
 
+	# git's --date=local (and log.date=local) omit the timezone offset, so
+	# treat that as an already-local time with a zero offset instead of
+	# dying on the undefined value below (warnings are fatal in this file).
+	$tz //= 0;
+
 	# Convert local time to UTC using timezone offset like -700
 	my $offset_hours   = int($tz / 100);
 	my $offset_minutes = abs($tz % 100);

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -296,11 +296,14 @@ sub do_dsf_stuff {
 		################################################
 		} elsif ($line =~ /^Date:.*?(\w.+)/) {
 			my $unixtime = git_datestr_unixtime($1);
-			my $diff     = time() - $unixtime;
-			my $human    = human_time_diff($diff, 1);
 
-			# Append the human string to the line
-			$line =~ s/$/ ($human)/;
+			if ($unixtime) {
+				my $diff  = time() - $unixtime;
+				my $human = human_time_diff($diff, 1);
+
+				# Append the human string to the line
+				$line =~ s/$/ ($human)/;
+			}
 
 			print $line;
 		########################################
@@ -1513,23 +1516,59 @@ sub draw_ruler {
 sub git_datestr_unixtime {
 	my $str = shift();
 
+	if ($str !~ /:/) {
+		return '';
+	}
+
 	my @p = split(' ', $str);
 
 	my %month = (
-		Jan => 0, Feb => 1, Mar => 2, Apr => 3,
-		May => 4, Jun => 5, Jul => 6, Aug => 7,
+		Jan => 0, Feb => 1, Mar => 2 , Apr => 3 ,
+		May => 4, Jun => 5, Jul => 6 , Aug => 7 ,
 		Sep => 8, Oct => 9, Nov => 10, Dec => 11,
 	);
 
-	my ($wday, $mon_str, $mday, $time, $year, $tz) = @p;
+	my ($wday, $mon_str, $mday, $time, $year, $tz, $mon);
+
+	# Wed Jul 15 08:31:07 2026 -0700
+	if (scalar(@p) == 6) {
+		($wday, $mon_str, $mday, $time, $year, $tz) = @p;
+	# This is --date iso: `2026-07-15 10:21:01 -0700`
+	} elsif (scalar(@p) == 3) {
+		my $date = $p[0] || "";
+		my @x    = split(/-/, $date);
+
+		$year = $x[0] || 0;
+		$mon  = $x[1] || 0;
+		$mday = $x[2] || 0;
+
+		# For timegm months start at zero
+		if ($mon) {
+			$mon--;
+		}
+
+		$time = $p[1] || "";
+		$tz   = $p[2] || "";
+	} else {
+		return "";
+	}
+
 	my ($hour, $min, $sec) = split /:/, $time;
 
-	my $mon = $month{$mon_str} || "";
+	if (!defined($sec)) {
+		return "";
+	}
+
+	if (!defined($mon)) {
+		$mon = $month{$mon_str} || "";
+	}
 
 	# Convert local time to UTC using timezone offset like -700
 	my $offset_hours   = int($tz / 100);
 	my $offset_minutes = abs($tz % 100);
 	my $offset_seconds = ($offset_hours * 3600) + ($offset_minutes * 60);
+
+	#print "TIME: sec=$sec min=$min hour=$hour day=$mday mon=$mon year=$year tz=$tz";
 
 	my $epoch = Time::Local::timegm($sec, $min, $hour, $mday, $mon, $year - 1900);
 	my $ret   = $epoch - $offset_seconds;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/so-fancy/diff-so-fancy"
+    "url": "git+https://github.com/so-fancy/diff-so-fancy.git"
   },
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/so-fancy/diff-so-fancy"
+    "url": "https://github.com/so-fancy/diff-so-fancy.git"
   },
   "keywords": [
     "git",

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -114,6 +114,13 @@ teardown_file() {
 	assert_line --index 8 --regexp "^\[COLOR227\]──────────────────────────┘"
 }
 
+@test "In 'git show' mode with ISO date we add a human time (#540)" {
+	output=$( load_fixture "gitshow-iso" | $diff_so_fancy | $ansi_reveal)
+	run printf "%s" "$output"
+
+	assert_line --index 4 --regexp "ago"
+}
+
 @test "Context lines starting with dash are not colored as removal (#542)" {
 	output=$( load_fixture "markdown-list" | $diff_so_fancy | $ansi_reveal )
 	run printf "%s" "$output"

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -114,6 +114,21 @@ teardown_file() {
 	assert_line --index 8 --regexp "^\[COLOR227\]──────────────────────────┘"
 }
 
+@test "Context lines starting with dash are not colored as removal (#542)" {
+	output=$( load_fixture "markdown-list" | $diff_so_fancy | $ansi_reveal )
+	run printf "%s" "$output"
+
+	# Context lines with dash content should have NO color
+	assert_line --index 5 --regexp '^- milk$'
+	assert_line --index 8 --regexp '^- butter$'
+
+	# Removal line should be RED
+	assert_line --index 6 --regexp '^\[BOLD\]\[RED\].*eggs'
+
+	# Addition line should be GREEN
+	assert_line --index 7 --regexp '^\[BOLD\]\[GREEN\].*bread'
+}
+
 @test "Patch mode line count matches on add/delete" {
 	for fixture in add_file_with_content delete_file_with_content; do
 		local in out

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -99,6 +99,12 @@ teardown_file() {
 	assert_line --index 1 --partial "modified: cancel.png (binary)";
 }
 
+@test "Handle binary modifications when the filename contains ' and '" {
+	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
+	run printf "%s" "$output"
+	assert_line --index 1 --partial "modified: a and b.png (binary)";
+}
+
 @test "Handle unicode characters in diff output" {
 	output=$( load_fixture "unicode" | $diff_so_fancy )
 	run printf "%s" "$output"

--- a/test/fixtures/binary-modified-name-with-and.diff
+++ b/test/fixtures/binary-modified-name-with-and.diff
@@ -1,0 +1,3 @@
+[1mdiff --git a/a and b.png b/a and b.png[m
+[1mindex 7ad49da..7f78f6f 100644[m
+Binary files a/a and b.png and b/a and b.png differ

--- a/test/fixtures/gitshow-iso.diff
+++ b/test/fixtures/gitshow-iso.diff
@@ -1,0 +1,19 @@
+commit acb77a7d5b19d609aa486e7cafc0a8486d7c56b0
+Author: Paul Irish <commits@paul.irish>
+Date:   2026-07-16 09:11:48 -0700
+
+    .git suffix in repo url
+
+diff --git a/package.json b/package.json
+index 79c50c4..b395a51 100644
+--- a/package.json
++++ b/package.json
+@@ -14,7 +14,7 @@
+   },
+   "repository": {
+     "type": "git",
+-    "url": "https://github.com/so-fancy/diff-so-fancy"
++    "url": "https://github.com/so-fancy/diff-so-fancy.git"
+   },
+   "keywords": [
+     "git",

--- a/test/fixtures/markdown-list.diff
+++ b/test/fixtures/markdown-list.diff
@@ -1,0 +1,10 @@
+diff --git a/list.md b/list.md
+index abc..def 100644
+--- a/list.md
++++ b/list.md
+@@ -1,4 +1,4 @@
+ shopping list:
+ - milk
+-- eggs
++- bread
+ - butter


### PR DESCRIPTION
## What's broken

A binary file whose name contains ` and ` is reported as a rename of a file that does not exist.

```
$ git init && printf '\x89PNG\x00\x01' > "a and b.png" && git add -A && git commit -m init
$ printf '\x89PNG\x00\x02\x03' > "a and b.png"
$ git diff
Binary files a/a and b.png and b/a and b.png differ

$ git diff | diff-so-fancy
renamed: a to b.png and b/a and b.png (binary)
```

The file was modified, not renamed, and neither of those paths exists.

Deleting it is worse, because the fabricated destination is `/dev/null`:

```
renamed: a to b.png and /dev/null (binary)
```

After:

```
modified: a and b.png (binary)
deleted:  a and b.png (binary)
```

## Cause

```perl
$line =~ /^Binary files (\w\/)?(.+?) and (\w\/)?(.+?) differ/
```

Both name captures are non-greedy, so the first ` and ` anywhere in the line ends the first filename. With `a and b.png` that is the one inside the name itself, and everything after it becomes the "second" file.

The sibling handler for `diff --git` lines already avoids this, using a greedy match, so only the binary path is affected.

## The fix

Capture the whole name section first, then split on the ` and ` that is followed by the b-side prefix (or `/dev/null`), which is the one git actually inserted. The old non-greedy split stays as a fallback for lines without a recognisable prefix, for example under `diff.noprefix`.

A line that matches neither is now passed through unchanged instead of producing a partly-undefined change string.

Unaffected, checked before and after against real git output: ordinary binary modify and add, binary rename, `diff.noprefix`, `diff.mnemonicPrefix` (`i/` and `w/`), and a degenerate `Binary files foo.png differ`.

## Verification

A test in `test/diff-so-fancy.bats` with a fixture in `test/fixtures/`, following the shape of the existing binary tests.

Reverting the script while keeping the test:

```
not ok 26 Handle binary modifications when the filename contains ' and '
#   `assert_line --index 1 --partial "modified: a and b.png (binary)";' failed
# -- line does not contain substring --
```

`./test/bats/bin/bats test` is 54 ok, 0 not ok (53 before this change). `perl -c diff-so-fancy` is syntax OK.

*Disclosure: written with AI assistance (Claude Code). I built the repro repositories, ran the before and after for both the modify and delete cases, checked the prefix variants, and ran the revert check myself.*
