### PR TITLE
Fix binary file parsing when the filename contains ' and '

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -434,8 +434,25 @@ sub do_dsf_stuff {
 		################################
 		# Look for binary file changes #
 		################################
-		} elsif ($line =~ /^Binary files (\w\/)?(.+?) and (\w\/)?(.+?) differ/) {
-			my $change = file_change_string($2,$4);
+		} elsif ($line =~ /^Binary files (.+) differ/) {
+			my $names = $1;
+
+			# a file name may itself contain " and ", so prefer the separator
+			# that is followed by the b-side prefix (or /dev/null)
+			my ($file_1,$file_2) = $names =~ /^(.+) and (\w\/.+|\/dev\/null)$/;
+			if (!defined($file_1)) {
+				($file_1,$file_2) = $names =~ /^(.+?) and (.+)$/;
+			}
+			if (!defined($file_1)) {
+				print $line;
+				$i++;
+				next;
+			}
+
+			$file_1 =~ s|^\w/||;
+			$file_2 =~ s|^\w/||;
+
+			my $change = file_change_string($file_1,$file_2);
 			my $str    = "$meta_color$change (binary)\n";
 
 			draw_ruler($str, $ruler_shape, $meta_color);

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -152,3 +152,9 @@ teardown_file() {
 		[ "$in" -eq "$out" ] || fail "fixture '$fixture' (bare): $in input lines but $out output lines"
 	done
 }
+
+@test "Binary file with ' and ' in the name (#547)" {
+	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
+	run printf "%s" "$output"
+	assert_line --index 1 --partial "modified: a and b.png (binary)";
+}

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -99,6 +99,12 @@ teardown_file() {
 	assert_line --index 1 --partial "modified: cancel.png (binary)";
 }
 
+@test "Handle binary modifications when the filename contains ' and '" {
+	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
+	run printf "%s" "$output"
+	assert_line --index 1 --partial "modified: a and b.png (binary)";
+}
+
 @test "Handle unicode characters in diff output" {
 	output=$( load_fixture "unicode" | $diff_so_fancy )
 	run printf "%s" "$output"

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -99,12 +99,6 @@ teardown_file() {
 	assert_line --index 1 --partial "modified: cancel.png (binary)";
 }
 
-@test "Handle binary modifications when the filename contains ' and ' (#547)" {
-	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
-	run printf "%s" "$output"
-	assert_line --index 1 --partial "modified: a and b.png (binary)";
-}
-
 @test "Handle unicode characters in diff output" {
 	output=$( load_fixture "unicode" | $diff_so_fancy )
 	run printf "%s" "$output"

--- a/test/diff-so-fancy.bats
+++ b/test/diff-so-fancy.bats
@@ -99,7 +99,7 @@ teardown_file() {
 	assert_line --index 1 --partial "modified: cancel.png (binary)";
 }
 
-@test "Handle binary modifications when the filename contains ' and '" {
+@test "Handle binary modifications when the filename contains ' and ' (#547)" {
 	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
 	run printf "%s" "$output"
 	assert_line --index 1 --partial "modified: a and b.png (binary)";

--- a/test/fixtures/binary-modified-name-with-and.diff
+++ b/test/fixtures/binary-modified-name-with-and.diff
@@ -1,0 +1,3 @@
+[1mdiff --git a/a and b.png b/a and b.png[m
+[1mindex 7ad49da..7f78f6f 100644[m
+Binary files a/a and b.png and b/a and b.png differ


### PR DESCRIPTION
## What's broken

A binary file whose name contains ` and ` is reported as a rename of a file that does not exist.

```
$ git init && printf '\x89PNG\x00\x01' > "a and b.png" && git add -A && git commit -m init
$ printf '\x89PNG\x00\x02\x03' > "a and b.png"
$ git diff
Binary files a/a and b.png and b/a and b.png differ

$ git diff | diff-so-fancy
renamed: a to b.png and b/a and b.png (binary)
```

The file was modified, not renamed, and neither of those paths exists.

Deleting it is worse, because the fabricated destination is `/dev/null`:

```
renamed: a to b.png and /dev/null (binary)
```

After:

```
modified: a and b.png (binary)
deleted:  a and b.png (binary)
```

## Cause

```perl
$line =~ /^Binary files (\w\/)?(.+?) and (\w\/)?(.+?) differ/
```

Both name captures are non-greedy, so the first ` and ` anywhere in the line ends the first filename. With `a and b.png` that is the one inside the name itself, and everything after it becomes the "second" file.

The sibling handler for `diff --git` lines already avoids this, using a greedy match, so only the binary path is affected.

## The fix

Capture the whole name section first, then split on the ` and ` that is followed by the b-side prefix (or `/dev/null`), which is the one git actually inserted. The old non-greedy split stays as a fallback for lines without a recognisable prefix, for example under `diff.noprefix`.

A line that matches neither is now passed through unchanged instead of producing a partly-undefined change string.

Unaffected, checked before and after against real git output: ordinary binary modify and add, binary rename, `diff.noprefix`, `diff.mnemonicPrefix` (`i/` and `w/`), and a degenerate `Binary files foo.png differ`.

## Verification

A test in `test/diff-so-fancy.bats` with a fixture in `test/fixtures/`, following the shape of the existing binary tests.

Reverting the script while keeping the test:

```
not ok 26 Handle binary modifications when the filename contains ' and '
#   `assert_line --index 1 --partial "modified: a and b.png (binary)";' failed
# -- line does not contain substring --
```

`./test/bats/bin/bats test` is 54 ok, 0 not ok (53 before this change). `perl -c diff-so-fancy` is syntax OK.

*Disclosure: written with AI assistance (Claude Code). I built the repro repositories, ran the before and after for both the modify and delete cases, checked the prefix variants, and ran the revert check myself.*
