### PR TITLE
Fix filename parsing when the path contains a 'b/' segment

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -265,10 +265,17 @@ sub do_dsf_stuff {
 				$last_file_seen = sanitize_display(basename($3 || ""));
 			# Git looks like: diff --git a/diff-so-fancy b/diff-so-fancy
 			} elsif ($extra =~ m/--git/) {
-				# Note file may contains spaces
-				my ($a_file, $b_file) = $extra =~ m/(a\/.+) (b\/.+)/;
+				# Note file may contains spaces, and a file name may itself
+				# contain " b/", so we first try to split on the position that
+				# makes both sides the same path (the common case)
+				my ($a_file) = bleach_text($extra) =~ m/^--git (\w\/(.+)) \w\/\2$/;
+
+				if (!defined($a_file)) {
+					# Note file may contains spaces
+					($a_file) = $extra =~ m/(a\/.+) b\/.+/;
+				}
+
 				$a_file ||= "";
-				$b_file ||= "";
 
 				$last_file_seen = sanitize_display($a_file);
 			}

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -153,6 +153,14 @@ teardown_file() {
 	done
 }
 
+@test "File with a 'b/' prefix inside the name (#549)" {
+	output=$( load_fixture "file-with-b-prefix-in-name" | $diff_so_fancy | $ansi_reveal )
+	run printf "%s" "$output"
+
+	assert_line --index 0 --partial "my b/file.txt changed file mode from 100644 to 100755"
+	assert_line --index 4 --partial "@ my b/old.txt:1 @"
+}
+
 @test "Binary file with ' and ' in the name (#547)" {
 	output=$( load_fixture "binary-modified-name-with-and" | $diff_so_fancy )
 	run printf "%s" "$output"

--- a/test/fixtures/file-with-b-prefix-in-name.diff
+++ b/test/fixtures/file-with-b-prefix-in-name.diff
@@ -1,0 +1,10 @@
+diff --git a/my b/file.txt b/my b/file.txt
+old mode 100644
+new mode 100755
+diff --git a/my b/old.txt b/my b/old.txt
+deleted file mode 100644
+index 286c5f5..0000000
+--- a/my b/old.txt	
++++ /dev/null
+@@ -1 +0,0 @@
+-gone


### PR DESCRIPTION
A path containing a `b/` segment breaks the filename parsing, so hunk headers and
mode-change lines carry trailing garbage.

Real repo, a file at `my b/file.txt`, piped through `git diff | diff-so-fancy`:

```
before:
deleted: my b/file.txt
@ my b/file.txt b/my:1 @
hello

after:
deleted: my b/file.txt
@ my b/file.txt:1 @
hello
```

Mode change, same file:

```
before: my b/file.txt b/my changed file mode from 100644 to 100755
after:  my b/file.txt changed file mode from 100644 to 100755
```

This shows up with any directory named `b`, which is not exotic: `lib b/`,
`src b/`, or a plain `b/` in a project that uses single-letter directories.

## Cause

The git header is parsed with two greedy captures:

```perl
my ($a_file, $b_file) = $extra =~ m/(a\/.+) (b\/.+)/;
```

For `diff --git a/my b/file.txt b/my b/file.txt`, `(a\/.+)` runs as far as it can
while still leaving something for ` (b\/.+)`, so `$a_file` swallows part of the
second path.

## The fix

Git writes the same path twice, so try that first: match when both sides are
identical, using a backreference.

```perl
my ($a_file) = bleach_text($extra) =~ m/^--git (\w\/(.+)) \w\/\2$/;
```

If that does not match, fall back to the previous behaviour, so anything the old
regex handled still works, including the cases where the two sides genuinely
differ.

Two details worth flagging:

- `bleach_text` is applied only for the match, because the raw `$extra` may carry
  colour codes that would break the backreference. The value assigned to
  `$last_file_seen` still goes through `sanitize_display` as before.
- `$b_file` was captured and never used, so I dropped it rather than leave a dead
  capture. Say the word if you would rather I keep it.

## Verification

Test in `test/bugs.bats` per the house rule, named with the PR number, and a
fixture generated from a real `git diff` rather than hand-written. It covers both
symptoms, the mode-change line and the hunk header.

Replacing the new regex with `my $a_file;`, so it always falls through to the old
greedy match, fails it:

```
not ok 16 File with a 'b/' prefix inside the name (#549)
#   `assert_line --index 0 --partial "my b/file.txt changed file mode from 100644 to 100755"' failed
# -- line does not contain substring --
# substring : my b/file.txt changed file mode from 100644 to 100755
# line      : my b/file.txt b/my changed file mode from 100644 to 100755
```

The suite goes from 54 to 55 passing, 0 failures.

Unrelated, noticed while testing and left alone: `Use of uninitialized value
$next` at line 470 when the input ends on an `old mode` line with nothing after
it. Happy to file that separately.

*Disclosure: written with AI assistance (Claude Code). The before and after above come from piping a real `git diff` through the script from each tree, and I ran the mutation check myself.*
