### PR TITLE
Fix a crash on a diff that ends on an 'old mode' line

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -468,13 +468,26 @@ sub do_dsf_stuff {
 		#####################################################
 		} elsif ($clean_permission_changes && $line =~ /^${ansi_color_regex}old mode (\d+)/) {
 			my ($old_mode) = $4;
-			my $next = shift(@$input);
+			my $line_color = $1;
+			my $next       = shift(@$input);
 
-			if ($1) {
-				print $1; # Print out whatever color we're using
+			my ($new_mode);
+			if (defined($next)) {
+				($new_mode) = $next =~ m/new mode (\d+)/;
 			}
 
-			my ($new_mode) = $next =~ m/new mode (\d+)/;
+			# The 'old mode' line isn't followed by a 'new mode' line (truncated
+			# input, or something else entirely). Print both lines untouched.
+			if (!defined($new_mode)) {
+				print $line;
+				unshift(@$input, $next) if defined($next);
+				$i++;
+				next;
+			}
+
+			if ($line_color) {
+				print $line_color; # Print out whatever color we're using
+			}
 
 			if ($patch_mode) {
 				print "\n";

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -166,3 +166,13 @@ teardown_file() {
 	run printf "%s" "$output"
 	assert_line --index 1 --partial "modified: a and b.png (binary)";
 }
+
+# A diff that ends right after 'old mode' made dsf warn about an
+# uninitialized value and abort (`use warnings FATAL => 'all'`).
+@test "Truncated diff ending on an 'old mode' line (#550)" {
+	run bash -c "cat '${BATS_TEST_DIRNAME}/fixtures/truncated-old-mode.diff' | $diff_so_fancy 2>&1"
+
+	assert_success
+	refute_output --partial "uninitialized value"
+	assert_line --index 0 --partial "old mode 100644"
+}

--- a/test/fixtures/truncated-old-mode.diff
+++ b/test/fixtures/truncated-old-mode.diff
@@ -1,0 +1,2 @@
+diff --git a/f.sh b/f.sh
+old mode 100644


### PR DESCRIPTION
A diff that ends on an `old mode` line with no `new mode` line after it kills
diff-so-fancy.

```
$ git diff | head -2 | diff-so-fancy
before:
Use of uninitialized value $next in pattern match (m//) at ./diff-so-fancy line 477, <STDIN> line 2.
exit=255

after:
old mode 100644
exit=0
```

A full diff of the same change is unaffected, before and after:

```
f.sh changed file mode from 100644 to 100755
```

Reachable by piping a diff through `head`, by a truncated or split chunk, or by
anything that feeds partial input.

## Cause

The `old mode` branch assumes the next line exists:

```perl
my $next = shift(@$input);
...
my ($new_mode) = $next =~ m/new mode (\d+)/;
```

With nothing left, `$next` is undef, and `use warnings FATAL => 'all'` turns the
resulting warning into a fatal error, hence exit 255 rather than a printed line.

## The fix

If there is no following `new mode` line, print the `old mode` line untouched and
put `$next` back on the input if there was one, so nothing is swallowed.

One extra change worth pointing out rather than hiding: the original read `$1`
for the line colour *before* matching `$next`, which was safe only because of
that ordering. The guard has to look at `$next` first, which would clobber `$1`,
so the colour is now captured into `my $line_color` up front. Same behaviour,
and it no longer depends on statement order.

## Verification

`Truncated diff ending on an 'old mode' line (#550)` in `test/bugs.bats`, with a
fixture generated from a real `git diff` rather than hand-written.

Reverting the guard fails it:

```
not ok 18 Truncated diff ending on an 'old mode' line (#550)
#   `assert_success' failed
# status : 255
# output : Use of uninitialized value $next in pattern match (m//) at .../diff-so-fancy line 474, <STDIN> line 2.
```

The suite goes from 55 to 56 passing, 0 failures.

*Disclosure: written with AI assistance (Claude Code). The before and after come from piping a real truncated `git diff` through the script from each tree, and I ran the mutation check myself.*
