### PR TITLE
Fix a crash on a diff that ends on an 'old mode' line

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -468,13 +468,26 @@ sub do_dsf_stuff {
 		#####################################################
 		} elsif ($clean_permission_changes && $line =~ /^${ansi_color_regex}old mode (\d+)/) {
 			my ($old_mode) = $4;
-			my $next = shift(@$input);
+			my $line_color = $1;
+			my $next       = shift(@$input);
 
-			if ($1) {
-				print $1; # Print out whatever color we're using
+			my ($new_mode);
+			if (defined($next)) {
+				($new_mode) = $next =~ m/new mode (\d+)/;
 			}
 
-			my ($new_mode) = $next =~ m/new mode (\d+)/;
+			# The 'old mode' line isn't followed by a 'new mode' line (truncated
+			# input, or something else entirely). Print both lines untouched.
+			if (!defined($new_mode)) {
+				print $line;
+				unshift(@$input, $next) if defined($next);
+				$i++;
+				next;
+			}
+
+			if ($line_color) {
+				print $line_color; # Print out whatever color we're using
+			}
 
 			if ($patch_mode) {
 				print "\n";

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -166,3 +166,13 @@ teardown_file() {
 	run printf "%s" "$output"
 	assert_line --index 1 --partial "modified: a and b.png (binary)";
 }
+
+# A diff that ends right after 'old mode' made dsf warn about an
+# uninitialized value and abort (`use warnings FATAL => 'all'`).
+@test "Truncated diff ending on an 'old mode' line (#550)" {
+	run bash -c "cat '${BATS_TEST_DIRNAME}/fixtures/truncated-old-mode.diff' | $diff_so_fancy 2>&1"
+
+	assert_success
+	refute_output --partial "uninitialized value"
+	assert_line --index 0 --partial "old mode 100644"
+}

--- a/test/fixtures/truncated-old-mode.diff
+++ b/test/fixtures/truncated-old-mode.diff
@@ -1,0 +1,2 @@
+diff --git a/f.sh b/f.sh
+old mode 100644


### PR DESCRIPTION
Reopens #550, split into two commits as you asked. Same code, which you already
said looks good.

A diff that ends on an `old mode` line with no `new mode` after it kills the
script:

```
$ git diff | head -2 | diff-so-fancy
before:
Use of uninitialized value $next in pattern match (m//) at ./diff-so-fancy line 477, <STDIN> line 2.
exit=255

after:
old mode 100644
exit=0
```

Reachable by piping a diff through `head`, or by any truncated chunk. A full
diff is unaffected either way.

`$next` is undef there, and `use warnings FATAL => 'all'` makes that fatal. The
fix prints the line untouched and puts `$next` back on the input.

One thing worth flagging: the original read `$1` for the line colour before
matching `$next`, which was only safe because of that ordering. The guard has to
look at `$next` first, so the colour is now captured into `my $line_color` up
front.

Commit 1 adds the test and fixture, and fails:

```
not ok 18 Truncated diff ending on an 'old mode' line (#550)
# status : 255
```

Commit 2 adds the fix, and the suite is 56 ok, 0 not ok.

Sorry for the new PR number: I had to delete and recreate the branch to reorder
the commits, and GitHub would not let me reopen #550 afterwards.
