### PR TITLE
Fix a diff that ends on a 'similarity index' line vanishing

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -504,34 +504,39 @@ sub do_dsf_stuff {
 		} elsif ($line =~ /^${ansi_color_regex}similarity index (\d+)%/) {
 			my $simil = $4;
 
-			# If it's a move with content change we ignore this and the next two lines
-			if ($simil != 100) {
-				shift(@$input);
-				shift(@$input);
+			my ($action1, $file1) = ($input->[0] || "") =~ /(copy|rename) from (.+?)(\e|\t|$)/;
+			my ($action2, $file2) = ($input->[1] || "") =~ /(copy|rename) to (.+?)(\e|\t|$)/;
+
+			# The 'from'/'to' pair git emits after a similarity index isn't there
+			# (truncated input, or something else entirely). Print the line
+			# untouched and consume nothing.
+			if (!$file1 || !$file2) {
+				print $line;
+				$i++;
 				next;
 			}
 
-			my $next    = shift(@$input) || "";
-			my ($action1, $file1) = $next =~ /(copy|rename) from (.+?)(\e|\t|$)/;
+			shift(@$input);
+			shift(@$input);
 
-			$next       = shift(@$input) || "";
-			my ($action2, $file2) = $next =~ /(copy|rename) to (.+?)(\e|\t|$)/;
-
-			if ($file1 && $file2) {
-				# We may not have extracted this yet, so we pull from the config if not
-				$meta_color = get_config_color("meta");
-
-				my $change = "???";
-				if ($action1 eq "copy") {
-					$change = "Copied $file1 to $file2";
-				} else {
-					$change = file_change_string($file1,$file2);
-				}
-
-				my $str = $meta_color . $change . "\n";
-
-				draw_ruler($str, $ruler_shape, $meta_color);
+			# If it's a move with content change we ignore this and the next two lines
+			if ($simil != 100) {
+				next;
 			}
+
+			# We may not have extracted this yet, so we pull from the config if not
+			$meta_color = get_config_color("meta");
+
+			my $change = "???";
+			if ($action1 eq "copy") {
+				$change = "Copied $file1 to $file2";
+			} else {
+				$change = file_change_string($file1,$file2);
+			}
+
+			my $str = $meta_color . $change . "\n";
+
+			draw_ruler($str, $ruler_shape, $meta_color);
 
 			$i += 3; # We've consumed three lines
 			next;

--- a/test/bugs.bats
+++ b/test/bugs.bats
@@ -176,3 +176,18 @@ teardown_file() {
 	refute_output --partial "uninitialized value"
 	assert_line --index 0 --partial "old mode 100644"
 }
+
+# A diff that ends right after 'similarity index' had its remaining lines
+# swallowed: the branch consumed the two lines it expects to follow without
+# checking they are there, so the whole diff vanished from the output.
+@test "Truncated diff ending on a 'similarity index' line" {
+	run bash -c "cat '${BATS_TEST_DIRNAME}/fixtures/truncated-similarity-index.diff' | $diff_so_fancy 2>&1"
+
+	assert_success
+	assert_line --index 0 --partial "similarity index 100%"
+
+	run bash -c "cat '${BATS_TEST_DIRNAME}/fixtures/truncated-similarity-index-partial.diff' | $diff_so_fancy 2>&1"
+
+	assert_success
+	assert_line --index 0 --partial "similarity index 85%"
+}

--- a/test/fixtures/truncated-similarity-index-partial.diff
+++ b/test/fixtures/truncated-similarity-index-partial.diff
@@ -1,0 +1,2 @@
+diff --git a/old.txt b/new.txt
+similarity index 85%

--- a/test/fixtures/truncated-similarity-index.diff
+++ b/test/fixtures/truncated-similarity-index.diff
@@ -1,0 +1,2 @@
+diff --git a/old.txt b/new.txt
+similarity index 100%


### PR DESCRIPTION
Same shape as #551, one branch over. A diff that ends on a `similarity index` line loses everything:

```
$ printf 'diff --git a/old.txt b/new.txt\nsimilarity index 100%%\n' | diff-so-fancy
before: (no output at all, exit 0)
after:  similarity index 100%
```

The rename branch consumes the two lines it expects to follow without checking they are there. On truncated input it consumes nothing and `next`s anyway, so the `similarity index` line goes too, and the whole diff disappears with a success exit code. Reachable the same way as #551, by piping through `head`.

It is not only truncation. Whatever the next two lines are, they are consumed:

```
$ printf 'diff --git a/old.txt b/new.txt\nsimilarity index 100%%\nnot a rename line\nanother line\n' | diff-so-fancy
before: (nothing)
after:  similarity index 100%
        not a rename line
        another line
```

The fix looks at `$input->[0]` and `$input->[1]` before consuming anything. If they are not the `from`/`to` pair git always emits there, the line is printed untouched and the input is left alone. Otherwise the two lines are shifted off exactly as before.

That reorders the branch a little: the `similarity index (\d+)%` check has to happen after the pair check rather than before it, since the `!= 100` path was the one consuming blind. The `100%` path is unchanged apart from losing its `if ($file1 && $file2)` wrapper, which the new guard now covers.

Commit 1 adds the test and fixtures, and fails:

```
not ok 19 Truncated diff ending on a 'similarity index' line
```

Commit 2 adds the fix, and the suite is 57 ok, 0 not ok.

Ran every fixture in `test/fixtures` through both versions: 38 of 39 are byte-identical, including `file-rename.diff`, `file_copy.diff`, `file-moves.diff` and `move_with_content_change.diff`, which are the ones that go through this branch. The 39th is `latin1.diff`, where the only difference is the script's own filename inside a UTF-8 warning.

Also checked the half-truncated case, `similarity index` followed by `rename from` and nothing else: before it printed nothing, after it prints both lines.

AI disclosure: written with Claude Code. I ran the script before and after on each of these inputs and on every fixture, and checked the test fails without the fix.
